### PR TITLE
Add a runtime AI executor switcher to the canvas header

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -89,6 +89,8 @@
       taglineResearch: "Mathematical physics, rigorous teaching, and verifiable code",
       taglineStudio: "A clean, focused studio for clear structure and practical answers",
       language: "Language",
+      agent: "Agent",
+      agentSwitched: "AI agent switched",
       theme: "Theme",
       themeArcane: "Arcane",
       themeScifi: "Sci-fi",
@@ -6436,6 +6438,31 @@
     };
   });
   document.querySelector("#theme").onchange = (e) => applyTheme(e.target.value);
+  const agentSelect = document.querySelector("#agentSelect");
+  function applyAgentConfig(config) {
+    if (!agentSelect || !config) return;
+    const availability = new Map((Array.isArray(config.aiExecutors) ? config.aiExecutors : []).map((executor) => [executor.id, executor.available === true]));
+    if (availability.size) Array.from(agentSelect.options).forEach((option) => { option.disabled = availability.get(option.value) === false; });
+    const current = String(config.aiProvider || "");
+    if (Array.from(agentSelect.options).some((option) => option.value === current)) agentSelect.value = current;
+  }
+  applyAgentConfig(window.PENECHO_CONFIG);
+  if (agentSelect) agentSelect.onchange = async () => {
+    const provider = agentSelect.value;
+    agentSelect.disabled = true;
+    try {
+      const response = await fetch("/api/ai/executor", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ provider }) });
+      const body = await response.json().catch(() => ({}));
+      if (!response.ok) throw new Error(body.error || `HTTP ${response.status}`);
+      applyAgentConfig(body);
+      setStatusKey("agentSwitched");
+    } catch (error) {
+      try { applyAgentConfig(await fetch("/api/config").then((response) => response.json())); } catch {}
+      setStatus(`${t("aiError")}${error.message}`);
+    } finally {
+      agentSelect.disabled = false;
+    }
+  };
   document.querySelector("#gridToggle").onclick = () => {
     state.gridVisible = !state.gridVisible;
     localStorage.setItem(state.theme === "research" ? "penecho-research-grid" : "penecho-grid", String(state.gridVisible));

--- a/public/index.html
+++ b/public/index.html
@@ -37,6 +37,13 @@
           <button type="button" data-language="en" aria-pressed="true">EN</button>
           <button type="button" data-language="zh" aria-pressed="false">中</button>
         </div>
+        <label class="theme-control agent-control"><span data-i18n="agent">Agent</span>
+            <select id="agentSelect" data-i18n-aria="agent" aria-label="Agent">
+              <option value="claude-cli">Claude CLI</option>
+              <option value="codex-cli">Codex CLI</option>
+              <option value="api">API</option>
+            </select>
+        </label>
         <label class="theme-control"><span data-i18n="theme">Theme</span>
             <select id="theme" data-i18n-aria="theme" aria-label="Theme">
               <option value="arcane" data-i18n="themeArcane">Arcane</option>

--- a/public/locales/zh.js
+++ b/public/locales/zh.js
@@ -9,6 +9,8 @@ window.PENECHO_LOCALES.zh = {
   taglineResearch: "数学物理研究、严谨教学与可验证代码",
   taglineStudio: "极简专注的工作室，清晰结构与实用解答",
   language: "语言",
+  agent: "执行端",
+  agentSwitched: "已切换 AI 执行端",
   theme: "主题",
   themeArcane: "奥术",
   themeScifi: "科幻",

--- a/server.js
+++ b/server.js
@@ -8,15 +8,15 @@ const os = require("os");
 const net = require("net");
 const { URL } = require("url");
 const { anthropicEffortParameters, anthropicResponseMaxTokens, normalizedApiEffort, resolveApiConfig } = require("./api-config.js");
-const { callCodexCli } = require("./codex-cli.js");
-const { callClaudeCli } = require("./claude-cli.js");
+const { callCodexCli, resolveCodexLaunch } = require("./codex-cli.js");
+const { callClaudeCli, resolveClaudeLaunch } = require("./claude-cli.js");
 const { NORMALIZE_TYPESET_POLICY } = require("./typeset.js");
 let sharp = null;
 try { sharp = require("sharp"); } catch {}
 
 const ROOT = __dirname;
 const PUBLIC = path.join(ROOT, "public");
-const AI_PROVIDER = normalizeAiProvider(process.env.AI_PROVIDER);
+let AI_PROVIDER = normalizeAiProvider(process.env.AI_PROVIDER);
 const API_BASE_URL = firstNonEmpty(process.env.AI_API_URL, process.env.OPENAI_API_URL);
 const API_FORMAT = firstNonEmpty(process.env.AI_API_FORMAT, process.env.OPENAI_API_FORMAT)?.toLowerCase();
 const API_KEY = firstNonEmpty(process.env.AI_API_KEY, process.env.OPENAI_API_KEY);
@@ -35,8 +35,8 @@ const debugRate = new Map();
 const MODEL = firstNonEmpty(process.env.AI_API_MODEL, process.env.OPENAI_MODEL);
 const API = resolveApiConfig(API_BASE_URL, API_FORMAT);
 const AI_IMAGE_FORMAT = normalizeAiImageFormat(process.env.PENECHO_AI_IMAGE_FORMAT);
-const AI_EFFORT = String(process.env.AI_EFFORT || "").trim() || null,
-  API_EFFORT = AI_PROVIDER === "api" ? normalizedApiEffort(API?.format, AI_EFFORT) : null;
+const AI_EFFORT = String(process.env.AI_EFFORT || "").trim() || null;
+let API_EFFORT = AI_PROVIDER === "api" ? normalizedApiEffort(API?.format, AI_EFFORT) : null;
 const autoDelayValue = process.env.AUTO_AI_DELAY_SECONDS?.trim();
 const configuredAutoDelay = autoDelayValue ? Number(autoDelayValue) : NaN;
 const AUTO_AI_DELAY_MS = Number.isFinite(configuredAutoDelay) && configuredAutoDelay >= 0 && configuredAutoDelay <= 60 ? Math.round(configuredAutoDelay * 1000) : 1200;
@@ -68,7 +68,10 @@ const CLAUDE_CLI = {
   effort: AI_EFFORT,
   timeoutMs:MODEL_TIMEOUT_MS,
 };
-const LOCAL_CLI = AI_PROVIDER === "codex-cli" ? { ...CODEX_CLI, label:"Codex CLI", doctor:"codex" } : AI_PROVIDER === "claude-cli" ? { ...CLAUDE_CLI, label:"Claude CLI", doctor:"claude" } : null;
+function computeLocalCli() {
+  return AI_PROVIDER === "codex-cli" ? { ...CODEX_CLI, label:"Codex CLI", doctor:"codex" } : AI_PROVIDER === "claude-cli" ? { ...CLAUDE_CLI, label:"Claude CLI", doctor:"claude" } : null;
+}
+let LOCAL_CLI = computeLocalCli();
 const AI_REQUEST_TIMEOUT_MS = MODEL_TIMEOUT_MS * 2 + 20000;
 const AI_SESSION_COOKIE_PREFIX = "penecho_ai_session";
 const AI_SESSION_TOKEN = crypto.randomBytes(32).toString("base64url");
@@ -122,10 +125,10 @@ function optionalBoolean(value) {
   return null;
 }
 
-function providerConfigurationError() {
-  if (!AI_PROVIDER) return "AI_PROVIDER must be api, codex-cli, or claude-cli.";
-  if (AI_PROVIDER === "api" && (!API || !MODEL)) return "Server must configure a valid AI_API_URL base URL and AI_API_MODEL. AI_API_FORMAT, when set, must be openai or anthropic.";
-  if (AI_PROVIDER === "api" && !API_KEY) return "Server is missing AI_API_KEY.";
+function providerConfigurationError(provider = AI_PROVIDER) {
+  if (!provider) return "AI_PROVIDER must be api, codex-cli, or claude-cli.";
+  if (provider === "api" && (!API || !MODEL)) return "Server must configure a valid AI_API_URL base URL and AI_API_MODEL. AI_API_FORMAT, when set, must be openai or anthropic.";
+  if (provider === "api" && !API_KEY) return "Server is missing AI_API_KEY.";
   if (!AI_IMAGE_FORMAT) return "PENECHO_AI_IMAGE_FORMAT must be webp or png when set.";
   if (AI_IMAGE_FORMAT === "webp" && !sharp) return "WebP image encoding is unavailable. Reinstall PenEcho so its Sharp dependency is present, or select PNG in Settings.";
   if (debugArtifactsValue === null) return "PENECHO_DEBUG_ARTIFACTS must be true or false when set.";
@@ -135,6 +138,36 @@ function providerConfigurationError() {
   return null;
 }
 
+function executorAvailable(provider) {
+  if (provider === "api") return Boolean(API && MODEL && API_KEY);
+  try {
+    if (provider === "codex-cli") { resolveCodexLaunch(CODEX_CLI.executable, process.env); return true; }
+    if (provider === "claude-cli") { resolveClaudeLaunch(CLAUDE_CLI.executable, process.env); return true; }
+  } catch { return false; }
+  return false;
+}
+function executorCatalog() {
+  return ["claude-cli", "codex-cli", "api"].map(id => ({ id, available: executorAvailable(id) }));
+}
+let anyCliAvailableCache = null;
+function anyCliAvailable() {
+  if (anyCliAvailableCache === null) anyCliAvailableCache = ["claude-cli", "codex-cli"].some(executorAvailable);
+  return anyCliAvailableCache;
+}
+function applyRuntimeProvider(provider) {
+  AI_PROVIDER = provider;
+  LOCAL_CLI = computeLocalCli();
+  API_EFFORT = AI_PROVIDER === "api" ? normalizedApiEffort(API?.format, AI_EFFORT) : null;
+}
+function uiConfigPayload() {
+  return { autoAiDelayMs: AUTO_AI_DELAY_MS, aiRequestTimeoutMs:AI_REQUEST_TIMEOUT_MS, aiProvider: AI_PROVIDER || "invalid", aiEffort:configuredUiEffort(), aiExecutors: executorCatalog() };
+}
+function executorSwitchError(req) {
+  const host = requestHost(req);
+  if (!host || !isAllowedCliHost(host.hostname)) return "Executor changes require the local PenEcho origin.";
+  if (!isLanClient(req.socket.remoteAddress)) return "Executor changes are available only from this computer or its local network.";
+  return browserRequestError(req);
+}
 function providerRequest(key, model, text, atlasImage = null, effort = API_EFFORT, literalTypeset = false, animationEnabled = false) {
   if (API.format === "anthropic") {
     const image = atlasImage ? imageDataUrlParts(atlasImage) : null;
@@ -451,10 +484,11 @@ function aiSessionCookieName(req) {
 function hasAiSession(req) {
   const name = aiSessionCookieName(req);
   if (!name) return false;
-  const cookie = String(req.headers.cookie || "").split(";").map(part => part.trim()).find(part => part.startsWith(`${name}=`));
-  if (!cookie) return false;
-  const value = cookie.slice(name.length + 1), actual = Buffer.from(value), expected = Buffer.from(AI_SESSION_TOKEN);
-  return actual.length === expected.length && crypto.timingSafeEqual(actual, expected);
+  const expected = Buffer.from(AI_SESSION_TOKEN);
+  return String(req.headers.cookie || "").split(";").map(part => part.trim()).filter(part => part.startsWith(`${name}=`)).some(cookie => {
+    const actual = Buffer.from(cookie.slice(name.length + 1));
+    return actual.length === expected.length && crypto.timingSafeEqual(actual, expected);
+  });
 }
 function browserRequestError(req, requireSession = true) {
   const host = requestHost(req), expectedOrigin = canonicalRequestOrigin(req), originText = typeof req.headers.origin === "string" ? req.headers.origin.trim() : "";
@@ -469,7 +503,7 @@ function aiSessionCookie(req) {
   const name = aiSessionCookieName(req);
   if (!name) return null;
   const secure = canonicalRequestOrigin(req)?.protocol === "https:" ? "; Secure" : "";
-  return `${name}=${AI_SESSION_TOKEN}; Path=/api/ai/command; HttpOnly; SameSite=Strict${secure}`;
+  return `${name}=${AI_SESSION_TOKEN}; Path=/api/ai; HttpOnly; SameSite=Strict${secure}`;
 }
 function supersedeLocalRequest(next) {
   const previous = activeLocalRequest;
@@ -850,8 +884,25 @@ const server = http.createServer(async (req, res) => {
   let url;
   try { url = new URL(req.url, "http://localhost"); } catch { return send(res, 400, "Bad Request", "text/plain; charset=utf-8"); }
   if (LOCAL_CLI && !canonicalRequestOrigin(req)) return send(res, 421, { error:"Request Host does not match the configured PenEcho origin." });
-  if (req.method === "GET" && url.pathname === "/api/config") return send(res, 200, { autoAiDelayMs: AUTO_AI_DELAY_MS, aiRequestTimeoutMs:AI_REQUEST_TIMEOUT_MS, aiProvider: AI_PROVIDER || "invalid", aiEffort:configuredUiEffort() });
-  if (req.method === "GET" && url.pathname === "/api/config.js") return send(res, 200, `window.PENECHO_CONFIG=${JSON.stringify({ autoAiDelayMs: AUTO_AI_DELAY_MS, aiRequestTimeoutMs:AI_REQUEST_TIMEOUT_MS, aiProvider: AI_PROVIDER || "invalid", aiEffort:configuredUiEffort() })};`, "application/javascript; charset=utf-8");
+  if (req.method === "GET" && url.pathname === "/api/config") return send(res, 200, uiConfigPayload());
+  if (req.method === "GET" && url.pathname === "/api/config.js") return send(res, 200, `window.PENECHO_CONFIG=${JSON.stringify(uiConfigPayload())};`, "application/javascript; charset=utf-8");
+  if (req.method === "POST" && url.pathname === "/api/ai/executor") {
+    const guardError = executorSwitchError(req);
+    if (guardError) return send(res, 403, { error: guardError });
+    if (String(req.headers["content-type"] || "").split(";",1)[0].trim().toLowerCase() !== "application/json") return send(res, 415, { error:"Executor changes require application/json." });
+    let body;
+    try { body = await readJson(req, 4096); } catch (error) { return send(res, 400, { error: error.message }); }
+    const provider = normalizeAiProvider(body?.provider);
+    if (!provider) return send(res, 400, { error:"provider must be api, codex-cli, or claude-cli." });
+    if (!executorAvailable(provider)) return send(res, 409, { error:`The ${provider} executor is not available on this server.` });
+    const configurationError = providerConfigurationError(provider);
+    if (configurationError) return send(res, 409, { error: configurationError });
+    if (provider !== AI_PROVIDER) {
+      applyRuntimeProvider(provider);
+      log({ type:"executor", provider, ip:req.socket.remoteAddress });
+    }
+    return send(res, 200, uiConfigPayload());
+  }
   if (req.method === "GET" && url.pathname === "/api/debug/log") {
     if (!DEBUG_ARTIFACTS || !isLoopback(req.socket.remoteAddress) || !isLoopbackHostname(requestHost(req)?.hostname)) return send(res, 404, "Not found", "text/plain; charset=utf-8");
     if (!fs.existsSync(LOG_FILE)) return send(res, 200, "No debug log yet.\n", "text/plain; charset=utf-8");
@@ -1025,7 +1076,7 @@ const server = http.createServer(async (req, res) => {
   const file = path.resolve(PUBLIC, "." + requested);
   if (!file.startsWith(PUBLIC + path.sep) || !fs.existsSync(file) || fs.statSync(file).isDirectory()) return send(res, 404, "Not found", "text/plain");
   const headers = { "Content-Type": MIME[path.extname(file)] || "application/octet-stream", "Cache-Control":"no-store", "Content-Security-Policy":"default-src 'self'; script-src 'self' https://cdn.jsdelivr.net; style-src 'self'; img-src 'self' blob: data:; connect-src 'self'; object-src 'none'; base-uri 'none'; frame-ancestors 'none'; form-action 'none'", "Referrer-Policy":"no-referrer", "X-Content-Type-Options":"nosniff", "Cross-Origin-Resource-Policy":"same-origin" };
-  if (LOCAL_CLI && requested === "/index.html") headers["Set-Cookie"] = aiSessionCookie(req);
+  if ((LOCAL_CLI || anyCliAvailable() && isAllowedCliHost(requestHost(req)?.hostname) && isLanClient(req.socket.remoteAddress)) && requested === "/index.html") headers["Set-Cookie"] = aiSessionCookie(req);
   res.writeHead(200, headers);
   if (req.method === "HEAD") return res.end();
   fs.createReadStream(file).pipe(res);


### PR DESCRIPTION
User-visible behavior: a new Agent select next to Theme lets the user switch the active executor (Claude CLI, Codex CLI, or API) without restarting the server. Executors that are not available on the server (CLI binary not found, API credentials not configured) are disabled in the select. The configured AI_PROVIDER remains the startup default; a switch lasts for the server process lifetime.

Implementation:
- server.js derives the provider-dependent state (LOCAL_CLI, API effort) through applyRuntimeProvider() instead of load-time consts.
- GET /api/config now includes aiExecutors availability; the new POST /api/ai/executor endpoint validates and applies the switch.
- The switch endpoint always enforces the strict CLI-grade checks regardless of the current mode: allowed local Host, LAN client, same-origin, session cookie, and JSON content type.
- The session cookie is scoped to Path=/api/ai so both AI commands and executor switches carry it; hasAiSession now checks every same-name cookie so a stale cookie from an earlier server run cannot mask the current one. In API mode the cookie is only issued to local/LAN clients with a local Host, preserving unrestricted remote API-mode behavior and its no-cookie guarantee for remote clients.

Validation: npm run check passes (180 tests); manually verified in the browser that switching agents updates /api/config, unavailable options are disabled, and canvas requests run through the selected executor.

Limitations: a switch is process-local and not persisted to the configuration file; Codex CLI and Claude CLI must be installed and authenticated on the server host to appear as available.

## Summary

Describe what changed and why.

## Validation

List the checks and browser interactions you performed.

## Contributor agreement

- [ ] I have read and agree to `CONTRIBUTOR-LICENSE-AGREEMENT.md` in this repository.
- [ ] I have the right to submit this contribution, including any required permission from my employer or other rights holder.
