### PR TITLE
Recover the AI session automatically after a server restart, and clar…

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -266,7 +266,7 @@
       outsideCanvas: "This is outside the canvas. Write on the paper.",
       selectionEmpty: "The selected area has no ink",
       selectionTooSmall: "Draw a larger closed lasso around some ink",
-      selectionReady: "Move or resize the selected lasso region",
+      selectionReady: "Move or resize the selection; click outside to apply it; ask AI about it via the orb",
       selectionCommitted: "Selection applied locally",
       selectionCancelled: "Selection cancelled",
       selectionRecolored: "Selection color changed locally",
@@ -3592,12 +3592,7 @@
     setStatusKey(isolatedSelection && action === "normalize" ? "selectionTypesetting" : "observing");
     const timeout = setTimeout(() => controller.abort(), state.aiRequestTimeoutMs);
     try {
-      const res = await fetch("/api/ai/command", {
-          signal: controller.signal,
-          method: "POST",
-          credentials: "same-origin",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
+      const aiRequestBody = JSON.stringify({
             ...packed,
             trigger: automatic ? "user_paused" : "manual",
             userAction: action,
@@ -3613,8 +3608,21 @@
               studio: "Minimal, well-organized general-purpose studio assistant. Prioritize clear structure, legible formatting, concise step-by-step reasoning, and practical actionable answers. Keep visual output clean and uncluttered; avoid decorative flourishes.",
             }[state.theme],
           }),
-        }),
+        sendAiCommand = () => fetch("/api/ai/command", {
+          signal: controller.signal,
+          method: "POST",
+          credentials: "same-origin",
+          headers: { "Content-Type": "application/json" },
+          body: aiRequestBody,
+        });
+      let res = await sendAiCommand(),
         data = await res.json();
+      if (res.status === 403 && /browser session/i.test(String(data?.error || ""))) {
+        // Сервер перезапустился и сессионная кука устарела: обновить её загрузкой "/" и повторить один раз.
+        await fetch("/", { credentials: "same-origin", cache: "no-store" });
+        res = await sendAiCommand();
+        data = await res.json();
+      }
       if (run.superseded || state.activeAI !== run) throw Error(AI_SUPERSEDED);
       rememberRequest(data.requestId);
       if (!res.ok) {

--- a/public/locales/zh.js
+++ b/public/locales/zh.js
@@ -186,7 +186,7 @@ window.PENECHO_LOCALES.zh = {
   outsideCanvas: "这里是画布外区域，请在白色纸面内书写",
   selectionEmpty: "选中区域内没有笔迹",
   selectionTooSmall: "请画一个更大的闭合套索并圈住笔迹",
-  selectionReady: "可移动或缩放套索选中的区域",
+  selectionReady: "可移动或缩放选区；点击选区外应用；通过右上角圆球向 AI 提问",
   selectionCommitted: "选区修改已在本地应用",
   selectionCancelled: "已取消选区修改",
   selectionRecolored: "已在本地修改选区颜色",


### PR DESCRIPTION
…ify selection guidance

- app.js: when an AI request is rejected with 403 'requires a same-origin browser session', refresh the process-lifetime session cookie by fetching '/' once and retry the request. Previously any server restart (the session token is regenerated on start) left open tabs with a stale cookie, so the next AI action - including asking about a lasso selection - failed with no obvious recovery short of a manual page reload.
- app.js: the selectionReady status now states how to act on a selection (click outside to apply, use the orb to ask AI), since the selection toolbar has no explicit confirm button and the previous text did not hint at the orb. English and Chinese strings updated.

## Summary

Describe what changed and why.

## Validation

List the checks and browser interactions you performed.

## Contributor agreement

- [ ] I have read and agree to `CONTRIBUTOR-LICENSE-AGREEMENT.md` in this repository.
- [ ] I have the right to submit this contribution, including any required permission from my employer or other rights holder.
