### PR TITLE
docs: add multilingual README translations

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -1,0 +1,110 @@
+<h1 align="center">
+  <img src="public/penecho-readme-header.png" alt="PenEcho" width="760">
+</h1>
+
+<p align="center">
+  <a href="README.md">English</a> |
+  <a href="README.zh-CN.md">简体中文</a> |
+  <a href="README.ja.md">日本語</a> |
+  <a href="README.ko.md">한국어</a> |
+  <a href="README.ru.md">Русский</a> |
+  <a href="README.es.md">Español</a> |
+  <a href="README.pt-BR.md">Português (Brasil)</a> |
+  <a href="README.fr.md">Français</a> |
+  <strong>Deutsch</strong>
+</p>
+
+<p align="center"><strong>Denke mit KI über das Chatfenster hinaus.</strong></p>
+
+<p align="center">PenEcho ist eine gemeinsame Leinwand, auf der Handschrift, Gleichungen, Diagramme und räumlicher Kontext Teil des Gesprächs werden.</p>
+
+<p align="center">
+  <a href="https://discord.gg/3jrPJ3mXdX"><img src="https://img.shields.io/badge/Discord-Community%20beitreten-5865F2?style=for-the-badge&amp;logo=discord&amp;logoColor=white" alt="PenEcho auf Discord beitreten"></a>
+  <a href="https://github.com/penecho/penecho/stargazers"><img src="https://img.shields.io/github/stars/penecho/penecho?style=for-the-badge&amp;logo=github&amp;logoColor=white&amp;color=f5b301" alt="PenEcho auf GitHub einen Stern geben"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/badge/License-AGPL%20v3-blue?style=for-the-badge" alt="Lizenz: AGPL v3"></a>
+</p>
+
+> Diese Übersetzung bietet einen Projektüberblick. Die aktuelle und vollständige technische Referenz ist die [englische README](README.md).
+
+<p align="center"><img src="https://github.com/penecho/penecho/releases/download/v0.1.0/penecho_plugins_sub_x10.webp" alt="PenEcho-Plugin-Demo" width="100%"></p>
+
+<p align="center"><img src="https://github.com/penecho/penecho/releases/download/v0.1.0/penecho_full_demo.webp" alt="Vollständige PenEcho-Demo" width="100%"></p>
+
+## Kimi Open Source Friends
+
+PenEcho ist offizielles Mitglied der **Kimi Open Source Friends**, einem Programm von [Moonshot AI](https://www.kimi.com/) zur Unterstützung herausragender Open-Source-Projekte. Das Kimi-Team unterstützt die Entwicklung mit API-Guthaben. Kimi K3 gehört zu den empfohlenen Modellen für anspruchsvolle Aufgaben mit Handschrift und Diagrammen.
+
+- [Kimi Code](https://www.kimi.com/code?aff=penecho) - weltweit verfügbares Coding-Abonnement
+- [Kimi Open Platform, China](https://platform.kimi.com?aff=penecho) - API-Zugang für Festlandchina
+- [Kimi Open Platform, international](https://platform.kimi.ai?aff=penecho) - API-Zugang für alle anderen Regionen
+
+## Schnellstart
+
+Du benötigst [Node.js 18.17 oder neuer](https://nodejs.org/) und eine der folgenden Optionen: einen API-Schlüssel, eine authentifizierte [Codex CLI](https://developers.openai.com/codex/cli) oder eine authentifizierte [Claude Code CLI](https://code.claude.com/docs/en/overview).
+
+```bash
+npm install -g penecho
+penecho configure
+penecho
+```
+
+Öffne [http://localhost:3888](http://localhost:3888). Mit `penecho configure` lassen sich LLM-Quelle, Modell, Reasoning-Stufe, Zeitlimit, Bildformat und Netzwerkschnittstelle interaktiv festlegen. Die Konfiguration wird standardmäßig unter `~/.penecho/config.env` gespeichert; API-Zugangsdaten werden niemals an den Browser gesendet.
+
+Aus dem Quellcode starten:
+
+```bash
+git clone https://github.com/penecho/penecho.git
+cd penecho
+npm install
+npm start
+```
+
+## Auf der Leinwand denken
+
+Schreibe eine Frage, Gleichung, Skizze oder unfertige Idee an eine beliebige Stelle der Leinwand und halte kurz inne. PenEcho erkennt die Striche und ihre räumlichen Beziehungen und platziert die Antwort daneben.
+
+- Zeichne natürlich mit Stift oder Maus und navigiere auf einer `20.000 x 20.000` großen Leinwand.
+- Erhalte Antworten, Hinweise, Erklärungen, Formeln, Funktionsgraphen und Diagramme direkt auf der Leinwand.
+- Verschiebe oder skaliere KI-Entwürfe und bestätige oder verwirf sie einzeln, bevor sie Teil deiner Arbeit werden.
+- Wähle Handschrift mit dem Lasso aus, um sie zu verschieben, zu skalieren, umzufärben, zu löschen oder mit Typeset sauber zu setzen.
+- Speichere Schnappschüsse lokal im Browser und exportiere bestätigte Inhalte als PNG.
+- Wähle zwischen den Designs Arcane, Sci-fi, Research und Studio.
+
+## Neu in Version 0.7.0
+
+- **Interaktives HTML auf der Leinwand.** Das General-HTML-Plugin erstellt Uhren, Rechner, Dashboards und andere Oberflächen als isolierte, interaktive Widgets.
+- **Nützliche Daten ohne PenEcho-Datendienst.** Plugins für Wetter, Aktien, Techniknachrichten, Wechselkurse, Erdbeben, Naturereignisse, Weltraumwetter und GitHub rufen deklarierte APIs direkt aus dem Browser auf.
+- **Klare Sicherheitsgrenzen.** Das Netzwerk jedes Plugins ist auf eine Positivliste beschränkt, HTML läuft in einem isolierten iframe und deaktivierte Plugins sind weder an Anfragen noch an der Laufzeit beteiligt.
+- **Lokale Plugin-Erstellung.** Ein kompaktes Markdown-Format unterstützt KI-Verbesserungen, automatische Titel, Speichern, Aktivieren und Löschen persönlicher Plugins in einer Preview-Oberfläche.
+- **Leinwandeigene Speicherung und Exporte.** Bestätigte Widgets erscheinen in Schnappschüssen und PNG-Dateien und unterstützen Verschieben, Umbruch, Skalierung sowie rückgängig machbares Löschen.
+- **Sinnvolle Voreinstellungen.** General HTML, Animation scenes und Weather sind für neue Benutzer aktiviert; weitere Daten-Plugins müssen ausdrücklich eingeschaltet werden.
+
+## Frühere Versionen
+
+- **0.6.0 - Animation scenes.** Ergänzte sichere deklarative Canvas2D-Animationen mit Bearbeitung und Schnappschuss-Persistenz, verbessertes Markdown/LaTeX-Rendering, robustere Modellausgaben und nicht blockierende npm-Updateprüfungen.
+
+## Funktionsweise
+
+<p align="center"><picture><source media="(prefers-color-scheme: dark)" srcset="docs/assets/how-it-works-dark.svg"><img alt="Funktionsweise von PenEcho" src="docs/assets/how-it-works-light.svg"></picture></p>
+
+Der Browser sendet nur den relevanten Ausschnitt der Leinwand und dessen Geometrie. Der Server prüft die Anfrage, leitet sie an den gewählten Executor weiter und gibt einen strukturierten, verschiebbaren Entwurf zurück. Aktuelle Modellempfehlungen und Kostenbeispiele stehen in der [englischen README](README.md#recommended-model-configurations).
+
+## Sichere Bereitstellung
+
+- **Codex CLI und Claude CLI:** Nur auf dem lokalen Rechner oder in einem vertrauenswürdigen LAN verwenden. Jede gültige Anfrage startet einen lokalen CLI-Prozess; diese Modi dürfen daher nicht direkt im Internet bereitgestellt werden.
+- **API-Modus:** Bei öffentlichem Zugriff sollte PenEcho hinter einem HTTPS-Proxy mit Authentifizierung sowie Begrenzungen für Anfragerate und -größe betrieben werden.
+- Veröffentliche keine Konfigurationsdateien, API-Schlüssel, Anfrageprotokolle, Logs oder privaten Leinwandbilder.
+
+## Mitwirken
+
+Führe vor dem Einreichen einer Änderung Folgendes aus:
+
+```bash
+npm run check
+```
+
+Weitere Informationen findest du in den [Architekturhinweisen](docs/architecture.md) und in [CONTRIBUTING.md](CONTRIBUTING.md). Fragen und Beispiele gehören in [Discord](https://discord.gg/3jrPJ3mXdX) oder [GitHub Discussions](https://github.com/penecho/penecho/discussions), reproduzierbare Fehler in [GitHub Issues](https://github.com/penecho/penecho/issues).
+
+## Lizenz und kommerzielle Nutzung
+
+PenEcho wird unter [GNU AGPL v3.0 only](LICENSE) veröffentlicht. Kommerzielle Nutzung ist erlaubt. Wenn du eine veränderte Version über ein Netzwerk bereitstellst, musst du den Benutzern gemäß AGPL den zugehörigen Quellcode anbieten. Für proprietäre Produkte und gehostete Dienste, die die AGPL nicht erfüllen können, ist eine separate [kommerzielle Lizenz](COMMERCIAL-LICENSE.md) erhältlich. Name und Logo unterliegen zusätzlich der [Markenrichtlinie](TRADEMARKS.md).

--- a/README.es.md
+++ b/README.es.md
@@ -1,0 +1,110 @@
+<h1 align="center">
+  <img src="public/penecho-readme-header.png" alt="PenEcho" width="760">
+</h1>
+
+<p align="center">
+  <a href="README.md">English</a> |
+  <a href="README.zh-CN.md">简体中文</a> |
+  <a href="README.ja.md">日本語</a> |
+  <a href="README.ko.md">한국어</a> |
+  <a href="README.ru.md">Русский</a> |
+  <strong>Español</strong> |
+  <a href="README.pt-BR.md">Português (Brasil)</a> |
+  <a href="README.fr.md">Français</a> |
+  <a href="README.de.md">Deutsch</a>
+</p>
+
+<p align="center"><strong>Piensa con IA más allá del chat.</strong></p>
+
+<p align="center">PenEcho es un lienzo compartido donde la escritura a mano, las ecuaciones, los diagramas y el contexto espacial forman parte de la conversación.</p>
+
+<p align="center">
+  <a href="https://discord.gg/3jrPJ3mXdX"><img src="https://img.shields.io/badge/Discord-Únete%20a%20la%20comunidad-5865F2?style=for-the-badge&amp;logo=discord&amp;logoColor=white" alt="Únete al Discord de PenEcho"></a>
+  <a href="https://github.com/penecho/penecho/stargazers"><img src="https://img.shields.io/github/stars/penecho/penecho?style=for-the-badge&amp;logo=github&amp;logoColor=white&amp;color=f5b301" alt="Da una estrella a PenEcho en GitHub"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/badge/License-AGPL%20v3-blue?style=for-the-badge" alt="Licencia: AGPL v3"></a>
+</p>
+
+> Esta traducción ofrece una visión general del proyecto. El [README en inglés](README.md) es la fuente canónica para la información técnica más reciente y completa.
+
+<p align="center"><img src="https://github.com/penecho/penecho/releases/download/v0.1.0/penecho_plugins_sub_x10.webp" alt="Demostración de plugins de PenEcho" width="100%"></p>
+
+<p align="center"><img src="https://github.com/penecho/penecho/releases/download/v0.1.0/penecho_full_demo.webp" alt="Demostración completa de PenEcho" width="100%"></p>
+
+## Kimi Open Source Friends
+
+PenEcho es miembro oficial de **Kimi Open Source Friends**, el programa de [Moonshot AI](https://www.kimi.com/) que apoya proyectos destacados de código abierto. El equipo de Kimi contribuye con créditos de API, y Kimi K3 es uno de los modelos recomendados para trabajo exigente con escritura y diagramas.
+
+- [Kimi Code](https://www.kimi.com/code?aff=penecho) - suscripción de programación disponible en todo el mundo
+- [Kimi Open Platform, China](https://platform.kimi.com?aff=penecho) - acceso a la API desde China continental
+- [Kimi Open Platform, global](https://platform.kimi.ai?aff=penecho) - acceso a la API desde el resto del mundo
+
+## Inicio rápido
+
+Necesitas [Node.js 18.17 o posterior](https://nodejs.org/) y una de estas opciones: una clave de API, un [Codex CLI](https://developers.openai.com/codex/cli) autenticado o un [Claude Code CLI](https://code.claude.com/docs/en/overview) autenticado.
+
+```bash
+npm install -g penecho
+penecho configure
+penecho
+```
+
+Abre [http://localhost:3888](http://localhost:3888). `penecho configure` permite seleccionar de forma interactiva la fuente LLM, el modelo, el nivel de razonamiento, el tiempo de espera, el formato de imagen y la interfaz de red. La configuración se guarda por defecto en `~/.penecho/config.env`; las credenciales de API nunca se envían al navegador.
+
+Para ejecutar el código fuente:
+
+```bash
+git clone https://github.com/penecho/penecho.git
+cd penecho
+npm install
+npm start
+```
+
+## Piensa sobre el lienzo
+
+Escribe una pregunta, ecuación, diagrama o idea incompleta en cualquier lugar del lienzo y haz una pausa. PenEcho interpreta los trazos y sus relaciones espaciales y coloca la respuesta junto a ellos.
+
+- Dibuja con lápiz o ratón y desplázate por un lienzo de `20 000 x 20 000`.
+- Obtén respuestas, pistas, explicaciones, fórmulas, gráficas y diagramas directamente sobre el lienzo.
+- Mueve y redimensiona borradores de IA; acéptalos o descártalos antes de incorporarlos al trabajo.
+- Selecciona tinta con el lazo para moverla, escalarla, cambiar su color, eliminarla o pasarla por Typeset.
+- Guarda instantáneas localmente en el navegador y exporta el contenido confirmado como PNG.
+- Elige entre los temas Arcane, Sci-fi, Research y Studio.
+
+## Novedades de la versión 0.7.0
+
+- **HTML interactivo en el lienzo.** El plugin General HTML permite crear relojes, calculadoras, paneles y otras interfaces como widgets interactivos aislados.
+- **Datos útiles sin un servicio de PenEcho.** Los plugins de clima, bolsa, noticias tecnológicas, divisas, terremotos, eventos naturales, clima espacial y GitHub consultan las API declaradas directamente desde el navegador.
+- **Límites de seguridad explícitos.** La red de cada plugin se restringe a una lista permitida, el HTML se ejecuta en un iframe aislado y los plugins desactivados no participan en las solicitudes ni en la ejecución.
+- **Creación local de plugins.** Un formato Markdown compacto permite mejorar borradores con IA, completar títulos, guardar, activar y eliminar plugins personales desde una interfaz preliminar.
+- **Persistencia y exportación propias del lienzo.** Los widgets confirmados se incluyen en instantáneas y PNG; admiten movimiento, redistribución, escalado y eliminación reversible.
+- **Valores predeterminados razonables.** General HTML, Animation scenes y Weather se activan para usuarios nuevos; los demás plugins de datos requieren activación explícita.
+
+## Versiones anteriores
+
+- **0.6.0 - Animation scenes.** Incorporó animaciones Canvas2D declarativas y seguras con edición y persistencia en instantáneas, mejor renderizado de Markdown/LaTeX, respuestas de modelos más robustas y comprobaciones de actualización de npm sin bloqueo.
+
+## Cómo funciona
+
+<p align="center"><picture><source media="(prefers-color-scheme: dark)" srcset="docs/assets/how-it-works-dark.svg"><img alt="Cómo funciona PenEcho" src="docs/assets/how-it-works-light.svg"></picture></p>
+
+El navegador solo envía el recorte pertinente del lienzo y su geometría. El servidor valida la solicitud, la dirige al ejecutor elegido y devuelve un borrador estructurado y móvil. Las recomendaciones actuales de modelos y los ejemplos de costes están en el [README en inglés](README.md#recommended-model-configurations).
+
+## Despliegue seguro
+
+- **Codex CLI y Claude CLI:** úsalos solo en el equipo local o en una red de confianza. Cada solicitud válida inicia un proceso CLI local, por lo que estos modos no deben exponerse directamente a Internet.
+- **Modo API:** si lo publicas, sitúa PenEcho detrás de un proxy HTTPS con autenticación y límites de frecuencia y tamaño de solicitud.
+- No publiques archivos de configuración, claves de API, trazas de solicitudes, registros ni imágenes privadas del lienzo.
+
+## Colabora con el proyecto
+
+Antes de enviar un cambio, ejecuta:
+
+```bash
+npm run check
+```
+
+Consulta las [notas de arquitectura](docs/architecture.md) y [CONTRIBUTING.md](CONTRIBUTING.md). Comparte preguntas y ejemplos en [Discord](https://discord.gg/3jrPJ3mXdX) o [GitHub Discussions](https://github.com/penecho/penecho/discussions), y comunica errores reproducibles en [GitHub Issues](https://github.com/penecho/penecho/issues).
+
+## Licencia y uso comercial
+
+PenEcho se publica bajo [GNU AGPL v3.0 only](LICENSE). Se permite el uso comercial, pero si ofreces una versión modificada a usuarios a través de una red, debes proporcionarles el código fuente correspondiente según la AGPL. Existe una [licencia comercial](COMMERCIAL-LICENSE.md) para productos propietarios y servicios alojados que no puedan cumplir la AGPL. El nombre y el logotipo están sujetos a la [política de marcas](TRADEMARKS.md).

--- a/README.fr.md
+++ b/README.fr.md
@@ -1,0 +1,110 @@
+<h1 align="center">
+  <img src="public/penecho-readme-header.png" alt="PenEcho" width="760">
+</h1>
+
+<p align="center">
+  <a href="README.md">English</a> |
+  <a href="README.zh-CN.md">简体中文</a> |
+  <a href="README.ja.md">日本語</a> |
+  <a href="README.ko.md">한국어</a> |
+  <a href="README.ru.md">Русский</a> |
+  <a href="README.es.md">Español</a> |
+  <a href="README.pt-BR.md">Português (Brasil)</a> |
+  <strong>Français</strong> |
+  <a href="README.de.md">Deutsch</a>
+</p>
+
+<p align="center"><strong>Pensez avec l'IA, au-delà de la fenêtre de discussion.</strong></p>
+
+<p align="center">PenEcho est un canevas partagé où l'écriture manuscrite, les équations, les schémas et le contexte spatial font partie de la conversation.</p>
+
+<p align="center">
+  <a href="https://discord.gg/3jrPJ3mXdX"><img src="https://img.shields.io/badge/Discord-Rejoindre%20la%20communauté-5865F2?style=for-the-badge&amp;logo=discord&amp;logoColor=white" alt="Rejoindre le Discord de PenEcho"></a>
+  <a href="https://github.com/penecho/penecho/stargazers"><img src="https://img.shields.io/github/stars/penecho/penecho?style=for-the-badge&amp;logo=github&amp;logoColor=white&amp;color=f5b301" alt="Ajouter une étoile à PenEcho sur GitHub"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/badge/License-AGPL%20v3-blue?style=for-the-badge" alt="Licence : AGPL v3"></a>
+</p>
+
+> Cette traduction présente une vue d'ensemble du projet. Le [README anglais](README.md) reste la source officielle pour les informations techniques les plus récentes et les plus complètes.
+
+<p align="center"><img src="https://github.com/penecho/penecho/releases/download/v0.1.0/penecho_plugins_sub_x10.webp" alt="Démonstration des plugins PenEcho" width="100%"></p>
+
+<p align="center"><img src="https://github.com/penecho/penecho/releases/download/v0.1.0/penecho_full_demo.webp" alt="Démonstration complète de PenEcho" width="100%"></p>
+
+## Kimi Open Source Friends
+
+PenEcho est membre officiel de **Kimi Open Source Friends**, le programme de [Moonshot AI](https://www.kimi.com/) qui soutient des projets open source remarquables. L'équipe Kimi contribue au développement avec des crédits d'API, et Kimi K3 fait partie des modèles recommandés pour les travaux exigeants mêlant écriture manuscrite et schémas.
+
+- [Kimi Code](https://www.kimi.com/code?aff=penecho) - abonnement de programmation disponible dans le monde entier
+- [Kimi Open Platform, Chine](https://platform.kimi.com?aff=penecho) - accès à l'API depuis la Chine continentale
+- [Kimi Open Platform, international](https://platform.kimi.ai?aff=penecho) - accès à l'API dans les autres régions
+
+## Démarrage rapide
+
+Vous avez besoin de [Node.js 18.17 ou version ultérieure](https://nodejs.org/) et de l'une des options suivantes : une clé d'API, un [Codex CLI](https://developers.openai.com/codex/cli) authentifié ou un [Claude Code CLI](https://code.claude.com/docs/en/overview) authentifié.
+
+```bash
+npm install -g penecho
+penecho configure
+penecho
+```
+
+Ouvrez [http://localhost:3888](http://localhost:3888). `penecho configure` permet de choisir de façon interactive la source LLM, le modèle, le niveau de raisonnement, le délai d'attente, le format d'image et l'interface réseau. La configuration est enregistrée par défaut dans `~/.penecho/config.env` ; les identifiants d'API ne sont jamais envoyés au navigateur.
+
+Pour exécuter le code source :
+
+```bash
+git clone https://github.com/penecho/penecho.git
+cd penecho
+npm install
+npm start
+```
+
+## Pensez sur le canevas
+
+Écrivez une question, une équation, un schéma ou une idée inachevée n'importe où sur le canevas, puis marquez une pause. PenEcho interprète les traits et leurs relations spatiales avant de placer la réponse à proximité.
+
+- Dessinez naturellement au stylet ou à la souris et parcourez un canevas de `20 000 x 20 000`.
+- Obtenez des réponses, indices, explications, formules, graphiques et schémas directement sur le canevas.
+- Déplacez et redimensionnez les brouillons de l'IA, puis acceptez-les ou rejetez-les avant de les intégrer à votre travail.
+- Sélectionnez des traits au lasso pour les déplacer, redimensionner, recolorer, supprimer ou les mettre au propre avec Typeset.
+- Enregistrez des instantanés localement dans le navigateur et exportez le contenu confirmé au format PNG.
+- Choisissez parmi les thèmes Arcane, Sci-fi, Research et Studio.
+
+## Nouveautés de la version 0.7.0
+
+- **HTML interactif sur le canevas.** Le plugin General HTML permet de créer des horloges, calculatrices, tableaux de bord et autres interfaces sous forme de widgets interactifs isolés.
+- **Des données utiles sans service PenEcho.** Les plugins de météo, bourse, actualités technologiques, devises, séismes, événements naturels, météo spatiale et GitHub interrogent directement les API déclarées depuis le navigateur.
+- **Des limites de sécurité explicites.** Le réseau de chaque plugin est restreint à une liste d'origines autorisées, le HTML s'exécute dans une iframe isolée et les plugins désactivés ne participent ni aux requêtes ni à l'exécution.
+- **Création locale de plugins.** Un format Markdown compact permet d'améliorer un brouillon avec l'IA, de compléter son titre, de l'enregistrer, de l'activer et de supprimer les plugins personnels depuis une interface Preview.
+- **Persistance et exportation intégrées au canevas.** Les widgets confirmés figurent dans les instantanés et les exports PNG, avec déplacement, redistribution, mise à l'échelle et suppression annulable.
+- **Des réglages par défaut raisonnables.** General HTML, Animation scenes et Weather sont activés pour les nouveaux utilisateurs ; les autres plugins de données doivent être activés explicitement.
+
+## Versions précédentes
+
+- **0.6.0 - Animation scenes.** Ajout d'animations Canvas2D déclaratives et sûres, avec édition et persistance dans les instantanés, amélioration du rendu Markdown/LaTeX, réponses des modèles plus robustes et vérification non bloquante des mises à jour npm.
+
+## Fonctionnement
+
+<p align="center"><picture><source media="(prefers-color-scheme: dark)" srcset="docs/assets/how-it-works-dark.svg"><img alt="Fonctionnement de PenEcho" src="docs/assets/how-it-works-light.svg"></picture></p>
+
+Le navigateur n'envoie que la zone pertinente du canevas et sa géométrie. Le serveur valide la requête, la transmet à l'exécuteur choisi et renvoie un brouillon structuré et déplaçable. Les recommandations actuelles de modèles et les exemples de coûts figurent dans le [README anglais](README.md#recommended-model-configurations).
+
+## Déploiement sécurisé
+
+- **Codex CLI et Claude CLI :** utilisez-les uniquement sur la machine locale ou un réseau de confiance. Chaque requête valide lance un processus CLI local ; n'exposez donc pas directement ces modes à Internet.
+- **Mode API :** en cas d'accès public, placez PenEcho derrière un proxy HTTPS avec authentification et limites de fréquence et de taille des requêtes.
+- Ne publiez pas les fichiers de configuration, clés d'API, traces de requêtes, journaux ou images privées du canevas.
+
+## Contribuer au projet
+
+Avant de proposer une modification, exécutez :
+
+```bash
+npm run check
+```
+
+Consultez les [notes d'architecture](docs/architecture.md) et [CONTRIBUTING.md](CONTRIBUTING.md). Partagez vos questions et exemples sur [Discord](https://discord.gg/3jrPJ3mXdX) ou [GitHub Discussions](https://github.com/penecho/penecho/discussions), et signalez les problèmes reproductibles dans [GitHub Issues](https://github.com/penecho/penecho/issues).
+
+## Licence et utilisation commerciale
+
+PenEcho est publié sous [GNU AGPL v3.0 only](LICENSE). L'utilisation commerciale est autorisée, mais si vous proposez une version modifiée à des utilisateurs via un réseau, vous devez leur fournir le code source correspondant conformément à l'AGPL. Une [licence commerciale](COMMERCIAL-LICENSE.md) distincte est disponible pour les produits propriétaires et services hébergés qui ne peuvent pas respecter l'AGPL. Le nom et le logo sont régis séparément par la [politique relative aux marques](TRADEMARKS.md).

--- a/README.ja.md
+++ b/README.ja.md
@@ -1,0 +1,110 @@
+<h1 align="center">
+  <img src="public/penecho-readme-header.png" alt="PenEcho" width="760">
+</h1>
+
+<p align="center">
+  <a href="README.md">English</a> |
+  <a href="README.zh-CN.md">简体中文</a> |
+  <strong>日本語</strong> |
+  <a href="README.ko.md">한국어</a> |
+  <a href="README.ru.md">Русский</a> |
+  <a href="README.es.md">Español</a> |
+  <a href="README.pt-BR.md">Português (Brasil)</a> |
+  <a href="README.fr.md">Français</a> |
+  <a href="README.de.md">Deutsch</a>
+</p>
+
+<p align="center"><strong>チャットボックスを越えて、AI と考える。</strong></p>
+
+<p align="center">PenEcho は、手書き、数式、図、空間的な文脈を対話の一部として扱える共有キャンバスです。</p>
+
+<p align="center">
+  <a href="https://discord.gg/3jrPJ3mXdX"><img src="https://img.shields.io/badge/Discord-コミュニティに参加-5865F2?style=for-the-badge&amp;logo=discord&amp;logoColor=white" alt="PenEcho Discord に参加"></a>
+  <a href="https://github.com/penecho/penecho/stargazers"><img src="https://img.shields.io/github/stars/penecho/penecho?style=for-the-badge&amp;logo=github&amp;logoColor=white&amp;color=f5b301" alt="GitHub で PenEcho にスターを付ける"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/badge/License-AGPL%20v3-blue?style=for-the-badge" alt="ライセンス: AGPL v3"></a>
+</p>
+
+> この翻訳はプロジェクトの概要を提供します。最新かつ完全な技術情報については、正本である [英語版 README](README.md) を参照してください。
+
+<p align="center"><img src="https://github.com/penecho/penecho/releases/download/v0.1.0/penecho_plugins_sub_x10.webp" alt="PenEcho プラグインのデモ" width="100%"></p>
+
+<p align="center"><img src="https://github.com/penecho/penecho/releases/download/v0.1.0/penecho_full_demo.webp" alt="PenEcho の全体デモ" width="100%"></p>
+
+## Kimi Open Source Friends
+
+PenEcho は、[Moonshot AI](https://www.kimi.com/) が優れたオープンソースプロジェクトを支援する **Kimi Open Source Friends** の公式メンバーです。Kimi チームは API クレジットで開発を支援しており、Kimi K3 は手書きや図を扱う高負荷なキャンバス作業に推奨されるモデルの一つです。
+
+- [Kimi Code](https://www.kimi.com/code?aff=penecho) - 世界各地で利用できるコーディングサブスクリプション
+- [Kimi Open Platform（中国）](https://platform.kimi.com?aff=penecho) - 中国本土向け API
+- [Kimi Open Platform（グローバル）](https://platform.kimi.ai?aff=penecho) - その他の地域向け API
+
+## クイックスタート
+
+[Node.js 18.17 以降](https://nodejs.org/)と、API キー、認証済みの [Codex CLI](https://developers.openai.com/codex/cli)、または認証済みの [Claude Code CLI](https://code.claude.com/docs/en/overview) のいずれかが必要です。
+
+```bash
+npm install -g penecho
+penecho configure
+penecho
+```
+
+ブラウザーで [http://localhost:3888](http://localhost:3888) を開きます。`penecho configure` では LLM ソース、モデル、推論レベル、タイムアウト、画像形式、待受アドレスなどを対話形式で設定できます。設定は既定で `~/.penecho/config.env` に保存され、API 認証情報がブラウザーへ送られることはありません。
+
+ソースから実行する場合:
+
+```bash
+git clone https://github.com/penecho/penecho.git
+cd penecho
+npm install
+npm start
+```
+
+## キャンバスで考える
+
+質問、数式、図、まだ形になっていないアイデアをキャンバスの好きな場所に書き、少し待つだけです。PenEcho は筆跡と空間的な関係を読み取り、その場に回答を配置します。
+
+- スタイラスまたはマウスで自然に描き、`20,000 x 20,000` のキャンバスをパン、ズームできます。
+- 回答、ヒント、説明、数式、プロット、図をキャンバス上に直接生成します。
+- AI の下書きは移動、サイズ変更、承認、破棄ができ、確定するまで元の内容とは分離されます。
+- 投げ縄で選択した手書きを移動、変形、色変更、削除、または Typeset で清書できます。
+- スナップショットをブラウザーに保存し、確定済みの内容を PNG として書き出せます。
+- Arcane、Sci-fi、Research、Studio のテーマを選べます。
+
+## 0.7.0 の新機能
+
+- **キャンバス上のライブ HTML。** General HTML プラグインにより、時計、電卓、ダッシュボードなどの操作可能な UI を、隔離されたウィジェットとして生成できます。
+- **データサービス不要のライブデータ。** 天気、株価、技術ニュース、為替、地震、自然現象、宇宙天気、GitHub の専用プラグインが、ブラウザーから宣言済み API へ直接接続します。
+- **明示的なセキュリティ境界。** 接続先はプラグインごとの許可リストに制限され、HTML は隔離 iframe で動作します。無効なプラグインはプロンプトや実行時処理に関与しません。
+- **ローカルプラグイン作成。** コンパクトな Markdown 形式、AI による改善、タイトル補完、保存、有効化、削除を Preview 版の作成画面から行えます。
+- **キャンバス標準の保存と出力。** 確定済みウィジェットはスナップショットと PNG 出力に含まれ、移動、リフロー、拡大縮小、取り消し可能な削除に対応します。
+- **実用的な既定値。** General HTML、Animation scenes、Weather は新規ユーザーで有効になり、その他のデータプラグインは明示的に有効化します。
+
+## 過去のリリース
+
+- **0.6.0 - Animation scenes。** 安全な宣言型 Canvas2D アニメーション、キャンバス上の編集とスナップショット保存、Markdown/LaTeX 描画の改善、モデル出力の堅牢化、ノンブロッキングな npm 更新確認を追加しました。
+
+## 仕組み
+
+<p align="center"><picture><source media="(prefers-color-scheme: dark)" srcset="docs/assets/how-it-works-dark.svg"><img alt="PenEcho の仕組み" src="docs/assets/how-it-works-light.svg"></picture></p>
+
+ブラウザーは関連するキャンバス領域と位置情報だけをサーバーへ送信します。サーバーがリクエストを検証して選択済みの実行系へ渡し、移動可能な構造化下書きを返します。現在の推奨モデルと料金例は [英語版 README](README.md#recommended-model-configurations) に掲載しています。
+
+## 安全な運用
+
+- **Codex CLI / Claude CLI:** ローカルマシンまたは信頼できる LAN だけで使用してください。有効なリクエストはローカル CLI プロセスを起動するため、公開インターネットへ直接公開しないでください。
+- **API モード:** 公開する場合は HTTPS、認証、レート制限、リクエストサイズ制限を備えたリバースプロキシの背後に配置してください。
+- 設定ファイル、API キー、リクエスト記録、ログ、非公開のキャンバス画像を公開しないでください。
+
+## 開発への参加
+
+変更を提出する前に次を実行してください。
+
+```bash
+npm run check
+```
+
+実装の概要は [アーキテクチャ資料](docs/architecture.md)、貢献方法は [CONTRIBUTING.md](CONTRIBUTING.md) を参照してください。質問や事例共有は [Discord](https://discord.gg/3jrPJ3mXdX) と [GitHub Discussions](https://github.com/penecho/penecho/discussions)、再現可能な不具合は [GitHub Issues](https://github.com/penecho/penecho/issues) へお願いします。
+
+## ライセンスと商用利用
+
+PenEcho は [GNU AGPL v3.0 only](LICENSE) で公開されています。商用利用は可能ですが、ネットワーク越しに変更版を提供する場合は、AGPL の条件に従って対応するソースコードを利用者へ提供する必要があります。AGPL に適合できないプロプライエタリ製品やホステッドサービス向けには、別途 [商用ライセンス](COMMERCIAL-LICENSE.md) があります。名称とロゴには [商標ポリシー](TRADEMARKS.md) が適用されます。

--- a/README.ko.md
+++ b/README.ko.md
@@ -1,0 +1,110 @@
+<h1 align="center">
+  <img src="public/penecho-readme-header.png" alt="PenEcho" width="760">
+</h1>
+
+<p align="center">
+  <a href="README.md">English</a> |
+  <a href="README.zh-CN.md">简体中文</a> |
+  <a href="README.ja.md">日本語</a> |
+  <strong>한국어</strong> |
+  <a href="README.ru.md">Русский</a> |
+  <a href="README.es.md">Español</a> |
+  <a href="README.pt-BR.md">Português (Brasil)</a> |
+  <a href="README.fr.md">Français</a> |
+  <a href="README.de.md">Deutsch</a>
+</p>
+
+<p align="center"><strong>채팅창을 넘어 AI와 함께 생각하세요.</strong></p>
+
+<p align="center">PenEcho는 손글씨, 수식, 다이어그램, 공간적 맥락을 대화의 일부로 만드는 공유 캔버스입니다.</p>
+
+<p align="center">
+  <a href="https://discord.gg/3jrPJ3mXdX"><img src="https://img.shields.io/badge/Discord-커뮤니티%20참여-5865F2?style=for-the-badge&amp;logo=discord&amp;logoColor=white" alt="PenEcho Discord 참여"></a>
+  <a href="https://github.com/penecho/penecho/stargazers"><img src="https://img.shields.io/github/stars/penecho/penecho?style=for-the-badge&amp;logo=github&amp;logoColor=white&amp;color=f5b301" alt="GitHub에서 PenEcho에 스타 주기"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/badge/License-AGPL%20v3-blue?style=for-the-badge" alt="라이선스: AGPL v3"></a>
+</p>
+
+> 이 번역은 프로젝트 개요를 제공합니다. 최신 전체 기술 정보는 공식 원문인 [영문 README](README.md)를 참조하세요.
+
+<p align="center"><img src="https://github.com/penecho/penecho/releases/download/v0.1.0/penecho_plugins_sub_x10.webp" alt="PenEcho 플러그인 데모" width="100%"></p>
+
+<p align="center"><img src="https://github.com/penecho/penecho/releases/download/v0.1.0/penecho_full_demo.webp" alt="PenEcho 전체 데모" width="100%"></p>
+
+## Kimi Open Source Friends
+
+PenEcho는 [Moonshot AI](https://www.kimi.com/)가 뛰어난 오픈 소스 프로젝트를 지원하는 **Kimi Open Source Friends**의 공식 멤버입니다. Kimi 팀은 API 크레딧으로 개발을 지원하며, Kimi K3는 손글씨와 다이어그램을 다루는 복잡한 캔버스 작업에 권장되는 모델 중 하나입니다.
+
+- [Kimi Code](https://www.kimi.com/code?aff=penecho) - 전 세계에서 이용할 수 있는 코딩 구독
+- [Kimi Open Platform 중국](https://platform.kimi.com?aff=penecho) - 중국 본토용 API
+- [Kimi Open Platform 글로벌](https://platform.kimi.ai?aff=penecho) - 기타 지역용 API
+
+## 빠른 시작
+
+[Node.js 18.17 이상](https://nodejs.org/)과 API 키, 인증된 [Codex CLI](https://developers.openai.com/codex/cli), 또는 인증된 [Claude Code CLI](https://code.claude.com/docs/en/overview) 중 하나가 필요합니다.
+
+```bash
+npm install -g penecho
+penecho configure
+penecho
+```
+
+브라우저에서 [http://localhost:3888](http://localhost:3888)을 여세요. `penecho configure`에서 LLM 소스, 모델, 추론 수준, 제한 시간, 이미지 형식, 수신 주소를 대화형으로 설정할 수 있습니다. 설정은 기본적으로 `~/.penecho/config.env`에 저장되며 API 자격 증명은 브라우저로 전송되지 않습니다.
+
+소스에서 실행하려면:
+
+```bash
+git clone https://github.com/penecho/penecho.git
+cd penecho
+npm install
+npm start
+```
+
+## 캔버스에서 생각하기
+
+질문, 수식, 다이어그램 또는 아직 다듬어지지 않은 아이디어를 캔버스 어디에나 쓰고 잠시 기다리세요. PenEcho는 획과 공간적 관계를 읽고 관련 위치에 답을 배치합니다.
+
+- 스타일러스나 마우스로 자연스럽게 그리고 `20,000 x 20,000` 캔버스를 이동하고 확대·축소합니다.
+- 답변, 힌트, 설명, 수식, 그래프, 다이어그램을 캔버스에서 바로 받습니다.
+- AI 초안을 이동하거나 크기를 조정한 뒤 작업에 포함하기 전에 개별적으로 승인하거나 폐기합니다.
+- 올가미로 필기를 선택해 이동, 크기 조정, 색상 변경, 삭제 또는 Typeset 정리를 수행합니다.
+- 브라우저에 스냅샷을 로컬로 저장하고 확정된 콘텐츠를 PNG로 내보냅니다.
+- Arcane, Sci-fi, Research, Studio 테마를 선택할 수 있습니다.
+
+## 0.7.0의 새로운 기능
+
+- **캔버스 위의 대화형 HTML.** General HTML 플러그인은 시계, 계산기, 대시보드 등의 인터페이스를 격리된 대화형 위젯으로 만들 수 있습니다.
+- **PenEcho 데이터 서비스 없이 유용한 데이터 사용.** 날씨, 주식, 기술 뉴스, 환율, 지진, 자연 현상, 우주 기상, GitHub 플러그인은 브라우저에서 선언된 API로 직접 요청합니다.
+- **명확한 보안 경계.** 각 플러그인의 네트워크는 허용 목록으로 제한되고 HTML은 격리된 iframe에서 실행됩니다. 비활성화된 플러그인은 요청이나 런타임에 관여하지 않습니다.
+- **로컬 플러그인 생성.** 간결한 Markdown 형식과 Preview 생성기에서 AI 개선, 자동 제목, 저장, 활성화, 개인 플러그인 삭제를 지원합니다.
+- **캔버스 기본 저장 및 내보내기.** 확정된 위젯은 스냅샷과 PNG에 포함되며 이동, 재배치, 전체 크기 조정, 실행 취소 가능한 삭제를 지원합니다.
+- **합리적인 기본값.** 새 사용자는 General HTML, Animation scenes, Weather가 기본 활성화되며 다른 데이터 플러그인은 직접 활성화해야 합니다.
+
+## 이전 릴리스
+
+- **0.6.0 - Animation scenes.** 안전한 선언형 Canvas2D 애니메이션, 캔버스 편집과 스냅샷 유지, 향상된 Markdown/LaTeX 렌더링, 더 안정적인 모델 출력, 비차단 npm 업데이트 확인을 추가했습니다.
+
+## 작동 방식
+
+<p align="center"><picture><source media="(prefers-color-scheme: dark)" srcset="docs/assets/how-it-works-dark.svg"><img alt="PenEcho 작동 방식" src="docs/assets/how-it-works-light.svg"></picture></p>
+
+브라우저는 관련 캔버스 영역과 기하 정보만 전송합니다. 서버는 요청을 검증해 선택한 실행기로 전달하고 이동 가능한 구조화 초안을 반환합니다. 최신 모델 권장 사항과 비용 예시는 [영문 README](README.md#recommended-model-configurations)를 참조하세요.
+
+## 안전한 배포
+
+- **Codex CLI 및 Claude CLI:** 로컬 컴퓨터나 신뢰할 수 있는 LAN에서만 사용하세요. 유효한 요청은 로컬 CLI 프로세스를 시작하므로 이 모드를 인터넷에 직접 공개하지 마세요.
+- **API 모드:** 공개할 경우 HTTPS, 인증, 요청 빈도와 크기 제한을 적용한 리버스 프록시 뒤에 배치하세요.
+- 설정 파일, API 키, 요청 추적, 로그 또는 비공개 캔버스 이미지를 공개하지 마세요.
+
+## 개발 참여
+
+변경 사항을 제출하기 전에 다음을 실행하세요.
+
+```bash
+npm run check
+```
+
+구현 정보는 [아키텍처 문서](docs/architecture.md), 기여 절차는 [CONTRIBUTING.md](CONTRIBUTING.md)를 참조하세요. 질문과 사용 사례는 [Discord](https://discord.gg/3jrPJ3mXdX) 또는 [GitHub Discussions](https://github.com/penecho/penecho/discussions)에 공유하고, 재현 가능한 문제는 [GitHub Issues](https://github.com/penecho/penecho/issues)에 등록해 주세요.
+
+## 라이선스 및 상업적 이용
+
+PenEcho는 [GNU AGPL v3.0 only](LICENSE)로 공개됩니다. 상업적 이용은 허용되지만, 수정한 버전을 네트워크를 통해 사용자에게 제공하는 경우 AGPL에 따라 해당 소스 코드를 제공해야 합니다. AGPL을 준수할 수 없는 독점 제품과 호스팅 서비스에는 별도의 [상업용 라이선스](COMMERCIAL-LICENSE.md)가 제공됩니다. 이름과 로고에는 [상표 정책](TRADEMARKS.md)이 별도로 적용됩니다.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,18 @@
   <img src="public/penecho-readme-header.png" alt="PenEcho" width="760">
 </h1>
 
+<p align="center">
+  <strong>English</strong> |
+  <a href="README.zh-CN.md">简体中文</a> |
+  <a href="README.ja.md">日本語</a> |
+  <a href="README.ko.md">한국어</a> |
+  <a href="README.ru.md">Русский</a> |
+  <a href="README.es.md">Español</a> |
+  <a href="README.pt-BR.md">Português (Brasil)</a> |
+  <a href="README.fr.md">Français</a> |
+  <a href="README.de.md">Deutsch</a>
+</p>
+
 <p align="center"><strong>Think with AI beyond the chat box.</strong></p>
 
 <p align="center">PenEcho is a shared canvas where handwriting, equations, diagrams, and spatial context become part of the conversation.</p>
@@ -57,8 +69,7 @@ Using these links directly supports the project:
 - [Quick start](#quick-start)
 - [Think on the canvas](#think-on-the-canvas)
 - [What's new in 0.7.0](#whats-new-in-070)
-- [What's new in 0.6.0](#whats-new-in-060)
-- [Animation scenes](#animation-scenes-in-060)
+- [Earlier releases](#earlier-releases)
 - [How it works](#how-it-works)
 - [Recommended model configurations](#recommended-model-configurations)
 - [Token use and cost](#token-use-and-cost)
@@ -177,33 +188,9 @@ PenEcho keeps a small local runtime and only allocates `512 x 512` tiles where i
 - **Canvas-native persistence and export.** Confirmed widgets participate in local snapshots and PNG export. Width and height handles reflow the interface without scaling its text, while the corner handle scales the whole widget like an image; deletion remains undoable.
 - **Sensible defaults.** General HTML, Animation scenes, and Weather start enabled for new users. All other data plugins remain opt-in, and every choice is remembered locally.
 
-## What's new in 0.6.0
+## Earlier releases
 
-- **Controllable animated explanations.** Declarative animation scenes are enabled by default so the model can use motion when explicitly requested or when it materially improves an explanation. The generic Plugins menu can turn them off, removing the additional 500–600 prompt tokens and restoring the original request and rendering behavior.
-- **Safe, persistent animation rendering.** Transparent Canvas2D scenes support up to 32 objects and 32 motions, play immediately, remain editable before and after confirmation, and persist through snapshots. The renderer uses a separate transparent layer with dirty-region updates, limits the canvas to 20 animations, and never executes model-provided JavaScript.
-- **Touch- and pen-friendly animation controls.** Mouse and pen clicks reveal the full animation toolbar immediately, while touch requires a one-second hold to avoid accidental activation during canvas panning. The toolbar and selection outline hide together after ten seconds, an outside click, or renewed drawing.
-- **More reliable model output.** Requests reserve output headroom, animation dimensions are bounded without encouraging oversized scenes, and the server can recover the first complete JSON response from harmless trailing model output. Invalid, incomplete, disabled, or over-limit animation commands remain rejected explicitly.
-- **Sharper text and draft rendering.** Confirmed text automatically formats safe Markdown and likely LaTeX, with Preview showing the same final result. Large downsampled AI drafts now clip against their logical dimensions, preventing the initial top-left-quarter rendering defect.
-- **Non-blocking npm updates.** Interactive starts bring the service online before checking npm, visibly report the installed version, and stop cleanly after an accepted global update so the upgraded service can be started manually.
-
-## Animation scenes in 0.6.0
-
-Animation is a removable plugin rather than a permanent requirement for every PenEcho request. `Animation scenes` is enabled by default in the canvas toolbar's `Plugins` menu. Clear its checkbox whenever you want the original static request and canvas behavior; PenEcho remembers that choice.
-
-- **When enabled:** the model may return an animated demonstration when you explicitly request one or when motion materially clarifies the answer. The additional animation protocol adds approximately `500–600` input tokens to each AI request.
-- **When disabled:** PenEcho omits the animation protocol and plugin field, filters new animation commands, and does not render animation scenes. Static requests and canvas behavior remain the same as before this feature. Previously saved scenes remain stored and become available again if the plugin is re-enabled.
-- **Transparent by design:** animation scenes have no background layer, allowing the paper, handwriting, diagrams, and other canvas content underneath to remain visible.
-
-For example, with the plugin enabled, you can write or ask for an animated orbital model, a moving geometry construction, interacting figures, or another process where change over time is part of the explanation. The model is instructed to choose a size that fits the actual request; `5000` logical units per axis is an upper bound, not a target.
-
-Returned scenes start playing while they are still editable drafts. Move or resize the draft, then accept or discard it like other AI output. After confirmation:
-
-- Click with a mouse or pen to reveal the complete editing controls immediately.
-- Touch and hold for one second to reveal them without interfering with ordinary one-finger canvas panning.
-- Use the controls to pause or resume, restart, move, resize, confirm an edit, cancel an edit, or delete the scene.
-- The toolbar, outline, and resize controls hide together after about ten seconds, an outside click, canvas navigation, a tool change, or a new pen stroke.
-
-Animation scenes are declarative JSON data rendered by PenEcho's own Canvas2D renderer; model-provided JavaScript is never executed. Each scene is limited to `32` objects and `32` motions, and a canvas can contain at most `20` animations. Only visible playing scenes request animation frames, complex visible scenes reduce their refresh rate, and changed screen regions are redrawn independently. Confirmed scenes and playback state are preserved in local snapshots, and enabled animations are captured at a fixed frame in previews, exports, and later model context.
+- **0.6.0 — Animation scenes.** Added optional, safe Canvas2D animations with canvas-native editing and snapshot persistence, alongside sharper Markdown/LaTeX rendering, more reliable model output, and non-blocking npm update checks.
 
 ## How it works
 

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -1,0 +1,110 @@
+<h1 align="center">
+  <img src="public/penecho-readme-header.png" alt="PenEcho" width="760">
+</h1>
+
+<p align="center">
+  <a href="README.md">English</a> |
+  <a href="README.zh-CN.md">简体中文</a> |
+  <a href="README.ja.md">日本語</a> |
+  <a href="README.ko.md">한국어</a> |
+  <a href="README.ru.md">Русский</a> |
+  <a href="README.es.md">Español</a> |
+  <strong>Português (Brasil)</strong> |
+  <a href="README.fr.md">Français</a> |
+  <a href="README.de.md">Deutsch</a>
+</p>
+
+<p align="center"><strong>Pense com IA além da caixa de chat.</strong></p>
+
+<p align="center">PenEcho é uma tela compartilhada onde escrita à mão, equações, diagramas e contexto espacial fazem parte da conversa.</p>
+
+<p align="center">
+  <a href="https://discord.gg/3jrPJ3mXdX"><img src="https://img.shields.io/badge/Discord-Participe%20da%20comunidade-5865F2?style=for-the-badge&amp;logo=discord&amp;logoColor=white" alt="Participe do Discord do PenEcho"></a>
+  <a href="https://github.com/penecho/penecho/stargazers"><img src="https://img.shields.io/github/stars/penecho/penecho?style=for-the-badge&amp;logo=github&amp;logoColor=white&amp;color=f5b301" alt="Dê uma estrela ao PenEcho no GitHub"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/badge/License-AGPL%20v3-blue?style=for-the-badge" alt="Licença: AGPL v3"></a>
+</p>
+
+> Esta tradução oferece uma visão geral do projeto. O [README em inglês](README.md) é a fonte oficial para as informações técnicas mais recentes e completas.
+
+<p align="center"><img src="https://github.com/penecho/penecho/releases/download/v0.1.0/penecho_plugins_sub_x10.webp" alt="Demonstração dos plugins do PenEcho" width="100%"></p>
+
+<p align="center"><img src="https://github.com/penecho/penecho/releases/download/v0.1.0/penecho_full_demo.webp" alt="Demonstração completa do PenEcho" width="100%"></p>
+
+## Kimi Open Source Friends
+
+O PenEcho é membro oficial do **Kimi Open Source Friends**, programa da [Moonshot AI](https://www.kimi.com/) que apoia projetos de código aberto de destaque. A equipe Kimi contribui com créditos de API, e o Kimi K3 é um dos modelos recomendados para trabalhos exigentes com escrita à mão e diagramas.
+
+- [Kimi Code](https://www.kimi.com/code?aff=penecho) - assinatura para programação disponível mundialmente
+- [Kimi Open Platform, China](https://platform.kimi.com?aff=penecho) - acesso à API na China continental
+- [Kimi Open Platform, global](https://platform.kimi.ai?aff=penecho) - acesso à API nas demais regiões
+
+## Início rápido
+
+Você precisa do [Node.js 18.17 ou mais recente](https://nodejs.org/) e de uma destas opções: uma chave de API, um [Codex CLI](https://developers.openai.com/codex/cli) autenticado ou um [Claude Code CLI](https://code.claude.com/docs/en/overview) autenticado.
+
+```bash
+npm install -g penecho
+penecho configure
+penecho
+```
+
+Abra [http://localhost:3888](http://localhost:3888). O comando `penecho configure` permite escolher de forma interativa a fonte de LLM, o modelo, o nível de raciocínio, o tempo limite, o formato de imagem e a interface de rede. Por padrão, as configurações ficam em `~/.penecho/config.env`; as credenciais de API nunca são enviadas ao navegador.
+
+Para executar a partir do código-fonte:
+
+```bash
+git clone https://github.com/penecho/penecho.git
+cd penecho
+npm install
+npm start
+```
+
+## Pense na tela
+
+Escreva uma pergunta, equação, diagrama ou ideia incompleta em qualquer lugar da tela e faça uma pausa. O PenEcho interpreta os traços e suas relações espaciais e posiciona a resposta ao lado deles.
+
+- Desenhe naturalmente com caneta ou mouse e navegue por uma tela de `20.000 x 20.000`.
+- Receba respostas, dicas, explicações, fórmulas, gráficos e diagramas diretamente na tela.
+- Mova e redimensione rascunhos da IA; aceite ou descarte cada um antes de incorporá-lo ao trabalho.
+- Selecione traços com o laço para mover, redimensionar, recolorir, excluir ou converter com Typeset.
+- Salve instantâneos localmente no navegador e exporte o conteúdo confirmado como PNG.
+- Escolha entre os temas Arcane, Sci-fi, Research e Studio.
+
+## Novidades da versão 0.7.0
+
+- **HTML interativo na tela.** O plugin General HTML permite criar relógios, calculadoras, painéis e outras interfaces como widgets interativos isolados.
+- **Dados úteis sem um serviço do PenEcho.** Plugins de clima, ações, notícias de tecnologia, câmbio, terremotos, eventos naturais, clima espacial e GitHub consultam as APIs declaradas diretamente pelo navegador.
+- **Limites de segurança explícitos.** A rede de cada plugin fica restrita a uma lista de origens permitidas, o HTML roda em um iframe isolado e plugins desativados não participam das solicitações nem da execução.
+- **Criação local de plugins.** Um formato Markdown compacto permite aprimorar rascunhos com IA, preencher títulos, salvar, ativar e excluir plugins pessoais em uma interface Preview.
+- **Persistência e exportação nativas.** Widgets confirmados fazem parte dos instantâneos e do PNG, com suporte a movimento, redistribuição, escala e exclusão reversível.
+- **Padrões sensatos.** General HTML, Animation scenes e Weather começam ativados para novos usuários; os outros plugins de dados exigem ativação explícita.
+
+## Versões anteriores
+
+- **0.6.0 - Animation scenes.** Adicionou animações Canvas2D declarativas e seguras, com edição e persistência em instantâneos, renderização aprimorada de Markdown/LaTeX, respostas de modelo mais robustas e verificação não bloqueante de atualizações do npm.
+
+## Como funciona
+
+<p align="center"><picture><source media="(prefers-color-scheme: dark)" srcset="docs/assets/how-it-works-dark.svg"><img alt="Como o PenEcho funciona" src="docs/assets/how-it-works-light.svg"></picture></p>
+
+O navegador envia apenas o recorte relevante da tela e sua geometria. O servidor valida a solicitação, encaminha ao executor escolhido e devolve um rascunho estruturado e móvel. As recomendações atuais de modelos e os exemplos de custo estão no [README em inglês](README.md#recommended-model-configurations).
+
+## Implantação segura
+
+- **Codex CLI e Claude CLI:** use apenas na máquina local ou em uma rede confiável. Cada solicitação válida inicia um processo CLI local, portanto esses modos não devem ficar expostos diretamente à internet.
+- **Modo API:** se houver acesso público, coloque o PenEcho atrás de um proxy HTTPS com autenticação e limites de frequência e tamanho de solicitação.
+- Não publique arquivos de configuração, chaves de API, rastros de solicitações, logs ou imagens privadas da tela.
+
+## Contribua com o projeto
+
+Antes de enviar uma alteração, execute:
+
+```bash
+npm run check
+```
+
+Consulte as [notas de arquitetura](docs/architecture.md) e o [CONTRIBUTING.md](CONTRIBUTING.md). Compartilhe dúvidas e exemplos no [Discord](https://discord.gg/3jrPJ3mXdX) ou no [GitHub Discussions](https://github.com/penecho/penecho/discussions), e registre erros reproduzíveis no [GitHub Issues](https://github.com/penecho/penecho/issues).
+
+## Licença e uso comercial
+
+O PenEcho é distribuído sob a [GNU AGPL v3.0 only](LICENSE). O uso comercial é permitido, mas, se você oferecer uma versão modificada a usuários pela rede, deverá fornecer a eles o código-fonte correspondente conforme a AGPL. Há uma [licença comercial](COMMERCIAL-LICENSE.md) para produtos proprietários e serviços hospedados que não possam cumprir a AGPL. O nome e o logotipo são regidos pela [política de marcas](TRADEMARKS.md).

--- a/README.ru.md
+++ b/README.ru.md
@@ -1,0 +1,110 @@
+<h1 align="center">
+  <img src="public/penecho-readme-header.png" alt="PenEcho" width="760">
+</h1>
+
+<p align="center">
+  <a href="README.md">English</a> |
+  <a href="README.zh-CN.md">简体中文</a> |
+  <a href="README.ja.md">日本語</a> |
+  <a href="README.ko.md">한국어</a> |
+  <strong>Русский</strong> |
+  <a href="README.es.md">Español</a> |
+  <a href="README.pt-BR.md">Português (Brasil)</a> |
+  <a href="README.fr.md">Français</a> |
+  <a href="README.de.md">Deutsch</a>
+</p>
+
+<p align="center"><strong>Думайте вместе с ИИ за пределами окна чата.</strong></p>
+
+<p align="center">PenEcho - это общий холст, где рукописный текст, формулы, схемы и пространственный контекст становятся частью диалога.</p>
+
+<p align="center">
+  <a href="https://discord.gg/3jrPJ3mXdX"><img src="https://img.shields.io/badge/Discord-Присоединиться-5865F2?style=for-the-badge&amp;logo=discord&amp;logoColor=white" alt="Присоединиться к Discord PenEcho"></a>
+  <a href="https://github.com/penecho/penecho/stargazers"><img src="https://img.shields.io/github/stars/penecho/penecho?style=for-the-badge&amp;logo=github&amp;logoColor=white&amp;color=f5b301" alt="Поставить звезду PenEcho на GitHub"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/badge/License-AGPL%20v3-blue?style=for-the-badge" alt="Лицензия: AGPL v3"></a>
+</p>
+
+> Этот перевод содержит обзор проекта. Актуальным и полным источником технической информации остается [README на английском языке](README.md).
+
+<p align="center"><img src="https://github.com/penecho/penecho/releases/download/v0.1.0/penecho_plugins_sub_x10.webp" alt="Демонстрация плагинов PenEcho" width="100%"></p>
+
+<p align="center"><img src="https://github.com/penecho/penecho/releases/download/v0.1.0/penecho_full_demo.webp" alt="Полная демонстрация PenEcho" width="100%"></p>
+
+## Kimi Open Source Friends
+
+PenEcho является официальным участником программы **Kimi Open Source Friends**, в рамках которой [Moonshot AI](https://www.kimi.com/) поддерживает заметные проекты с открытым исходным кодом. Команда Kimi предоставляет проекту API-кредиты, а Kimi K3 входит в число рекомендуемых моделей для сложной работы с рукописным текстом и схемами.
+
+- [Kimi Code](https://www.kimi.com/code?aff=penecho) - подписка для программирования, доступная по всему миру
+- [Kimi Open Platform, Китай](https://platform.kimi.com?aff=penecho) - API для материкового Китая
+- [Kimi Open Platform, весь мир](https://platform.kimi.ai?aff=penecho) - API для остальных регионов
+
+## Быстрый старт
+
+Потребуется [Node.js 18.17 или новее](https://nodejs.org/), а также ключ API, авторизованный [Codex CLI](https://developers.openai.com/codex/cli) или авторизованный [Claude Code CLI](https://code.claude.com/docs/en/overview).
+
+```bash
+npm install -g penecho
+penecho configure
+penecho
+```
+
+Откройте [http://localhost:3888](http://localhost:3888). Команда `penecho configure` позволяет интерактивно выбрать источник LLM, модель, уровень рассуждения, тайм-аут, формат изображения и сетевой адрес. По умолчанию настройки сохраняются в `~/.penecho/config.env`; учетные данные API не передаются в браузер.
+
+Запуск из исходного кода:
+
+```bash
+git clone https://github.com/penecho/penecho.git
+cd penecho
+npm install
+npm start
+```
+
+## Думайте на холсте
+
+Напишите вопрос, формулу, нарисуйте схему или набросок идеи в любом месте холста и сделайте паузу. PenEcho распознает штрихи и пространственные связи, а затем размещает ответ рядом.
+
+- Рисуйте пером или мышью и перемещайтесь по холсту размером `20 000 x 20 000`.
+- Получайте ответы, подсказки, объяснения, формулы, графики и схемы прямо на холсте.
+- Перемещайте и масштабируйте черновики ИИ, затем подтверждайте или отклоняйте их независимо от исходного содержимого.
+- Выделяйте рукописные элементы лассо, чтобы перемещать, масштабировать, перекрашивать, удалять или набирать их через Typeset.
+- Сохраняйте снимки локально в браузере и экспортируйте подтвержденное содержимое в PNG.
+- Выбирайте темы Arcane, Sci-fi, Research или Studio.
+
+## Что нового в 0.7.0
+
+- **Интерактивный HTML на холсте.** Плагин General HTML позволяет создавать часы, калькуляторы, панели и другие интерфейсы в изолированных интерактивных виджетах.
+- **Полезные данные без сервиса PenEcho.** Плагины погоды, акций, технических новостей, валют, землетрясений, природных событий, космической погоды и GitHub обращаются из браузера напрямую к заявленным API.
+- **Явные границы безопасности.** Сеть каждого плагина ограничена списком разрешенных адресов, HTML работает в изолированном iframe, а отключенные плагины полностью исключаются из запросов и среды выполнения.
+- **Создание локальных плагинов.** Компактный формат Markdown поддерживает улучшение с помощью ИИ, автоматическое название, сохранение, включение и удаление личных плагинов в интерфейсе Preview.
+- **Штатное сохранение и экспорт.** Подтвержденные виджеты входят в снимки и PNG, поддерживают перемещение, изменение компоновки и масштаба, а удаление можно отменить.
+- **Разумные настройки по умолчанию.** General HTML, Animation scenes и Weather включены для новых пользователей; остальные плагины данных включаются явно.
+
+## Предыдущие выпуски
+
+- **0.6.0 - Animation scenes.** Добавлены безопасные декларативные анимации Canvas2D с редактированием и сохранением снимков, улучшенный вывод Markdown/LaTeX, более надежная обработка ответов моделей и неблокирующая проверка обновлений npm.
+
+## Как это работает
+
+<p align="center"><picture><source media="(prefers-color-scheme: dark)" srcset="docs/assets/how-it-works-dark.svg"><img alt="Как работает PenEcho" src="docs/assets/how-it-works-light.svg"></picture></p>
+
+Браузер отправляет только относящийся к задаче фрагмент холста и геометрию. Сервер проверяет запрос, передает его выбранному исполнителю и возвращает структурированный перемещаемый черновик. Текущие рекомендации по моделям и примеры стоимости приведены в [английском README](README.md#recommended-model-configurations).
+
+## Безопасное развертывание
+
+- **Codex CLI и Claude CLI:** используйте только на локальном компьютере или в доверенной локальной сети. Корректный запрос запускает локальный процесс CLI, поэтому не публикуйте эти режимы напрямую в интернете.
+- **Режим API:** при публичном доступе размещайте PenEcho за HTTPS-прокси с аутентификацией, ограничением частоты и размера запросов.
+- Не публикуйте файлы конфигурации, ключи API, трассировки запросов, журналы и приватные изображения холста.
+
+## Участие в разработке
+
+Перед отправкой изменений выполните:
+
+```bash
+npm run check
+```
+
+Устройство проекта описано в [документе об архитектуре](docs/architecture.md), а правила участия - в [CONTRIBUTING.md](CONTRIBUTING.md). Вопросы и примеры можно обсуждать в [Discord](https://discord.gg/3jrPJ3mXdX) и [GitHub Discussions](https://github.com/penecho/penecho/discussions), а воспроизводимые ошибки следует оформлять в [GitHub Issues](https://github.com/penecho/penecho/issues).
+
+## Лицензия и коммерческое использование
+
+PenEcho распространяется на условиях [GNU AGPL v3.0 only](LICENSE). Коммерческое использование разрешено. Если измененная версия доступна пользователям по сети, необходимо предоставить им соответствующий исходный код на условиях AGPL. Для проприетарных продуктов и размещаемых сервисов, которые не могут соблюдать AGPL, доступна отдельная [коммерческая лицензия](COMMERCIAL-LICENSE.md). Название и логотип регулируются [политикой товарных знаков](TRADEMARKS.md).

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,0 +1,110 @@
+<h1 align="center">
+  <img src="public/penecho-readme-header.png" alt="PenEcho" width="760">
+</h1>
+
+<p align="center">
+  <a href="README.md">English</a> |
+  <strong>简体中文</strong> |
+  <a href="README.ja.md">日本語</a> |
+  <a href="README.ko.md">한국어</a> |
+  <a href="README.ru.md">Русский</a> |
+  <a href="README.es.md">Español</a> |
+  <a href="README.pt-BR.md">Português (Brasil)</a> |
+  <a href="README.fr.md">Français</a> |
+  <a href="README.de.md">Deutsch</a>
+</p>
+
+<p align="center"><strong>跳出聊天框，与 AI 一起思考。</strong></p>
+
+<p align="center">PenEcho 是一块共享画布，让手写内容、公式、图表和空间关系都成为对话的一部分。</p>
+
+<p align="center">
+  <a href="https://discord.gg/3jrPJ3mXdX"><img src="https://img.shields.io/badge/Discord-加入社区-5865F2?style=for-the-badge&amp;logo=discord&amp;logoColor=white" alt="加入 PenEcho Discord"></a>
+  <a href="https://github.com/penecho/penecho/stargazers"><img src="https://img.shields.io/github/stars/penecho/penecho?style=for-the-badge&amp;logo=github&amp;logoColor=white&amp;color=f5b301" alt="在 GitHub 上为 PenEcho 点亮 Star"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/badge/License-AGPL%20v3-blue?style=for-the-badge" alt="许可证：AGPL v3"></a>
+</p>
+
+> 本译文提供项目概览。最新、最完整的技术信息以[英文 README](README.md) 为准。
+
+<p align="center"><img src="https://github.com/penecho/penecho/releases/download/v0.1.0/penecho_plugins_sub_x10.webp" alt="PenEcho 插件演示" width="100%"></p>
+
+<p align="center"><img src="https://github.com/penecho/penecho/releases/download/v0.1.0/penecho_full_demo.webp" alt="PenEcho 完整演示" width="100%"></p>
+
+## Kimi 开源伙伴
+
+PenEcho 是 **Kimi Open Source Friends** 的正式成员。该计划由 [Moonshot AI](https://www.kimi.com/) 发起，用于支持优秀的开源项目。Kimi 团队通过 API 额度支持 PenEcho 的开发；Kimi K3 也是处理手写内容、图表等复杂画布任务时的推荐模型之一。
+
+- [Kimi Code](https://www.kimi.com/code?aff=penecho) - 面向全球用户的编程订阅服务
+- [Kimi 开放平台（中国）](https://platform.kimi.com?aff=penecho) - 中国大陆 API 服务
+- [Kimi 开放平台（全球）](https://platform.kimi.ai?aff=penecho) - 其他地区 API 服务
+
+## 快速开始
+
+你需要安装 [Node.js 18.17 或更高版本](https://nodejs.org/)，并准备以下任意一种方式：API Key、已登录的 [Codex CLI](https://developers.openai.com/codex/cli)，或已登录的 [Claude Code CLI](https://code.claude.com/docs/en/overview)。
+
+```bash
+npm install -g penecho
+penecho configure
+penecho
+```
+
+在浏览器中打开 [http://localhost:3888](http://localhost:3888)。通过 `penecho configure` 可以交互式设置 LLM 来源、模型、推理等级、超时时间、图片格式和监听地址。配置默认保存在 `~/.penecho/config.env`，API 凭据不会发送到浏览器。
+
+从源码运行：
+
+```bash
+git clone https://github.com/penecho/penecho.git
+cd penecho
+npm install
+npm start
+```
+
+## 在画布上思考
+
+在画布任意位置写下问题、公式、图表或尚未成形的想法，然后稍作停顿。PenEcho 会理解笔迹及其空间关系，并把回答直接放在相关内容旁边。
+
+- 使用手写笔或鼠标自然书写，在 `20,000 x 20,000` 的大画布上平移和缩放。
+- 直接在画布上获得答案、提示、解释、公式、函数图像和图表。
+- 移动或缩放 AI 草稿，并在它们成为正式内容前逐项接受或丢弃。
+- 用套索选择笔迹，进行移动、缩放、改色、删除，或通过 Typeset 将内容规范排版。
+- 在浏览器中保存本地快照，并将确认后的画布内容导出为 PNG。
+- 可选择 Arcane、Sci-fi、Research 或 Studio 主题。
+
+## 0.7.0 新功能
+
+- **画布上的交互式 HTML。** General HTML 插件可以生成时钟、计算器、仪表盘等界面，并以隔离的交互式组件直接呈现在画布上。
+- **无需 PenEcho 数据服务即可获取实用数据。** 天气、股票、科技新闻、汇率、地震、自然事件、太空天气和 GitHub 插件会由浏览器直接访问各自声明的 API。
+- **明确的安全边界。** 每个插件只能连接允许列表中的来源，HTML 在隔离的 iframe 中运行；停用的插件不会参与 AI 请求或运行时处理。
+- **创建本地插件。** 使用紧凑的 Markdown 格式定义能力，并可在预览版创建器中通过 AI 改进草稿、自动补全标题、保存启用或删除个人插件。
+- **画布原生的持久化与导出。** 确认后的组件可保存到本地快照并导出为 PNG，同时支持移动、重排、整体缩放和可撤销删除。
+- **合理的默认配置。** 新用户默认启用 General HTML、Animation scenes 和 Weather，其他数据插件需要手动选择启用。
+
+## 历史版本
+
+- **0.6.0 - Animation scenes。** 增加安全的声明式 Canvas2D 动画、画布编辑和快照持久化，并改进 Markdown/LaTeX 渲染、模型输出可靠性和非阻塞式 npm 更新检查。
+
+## 工作原理
+
+<p align="center"><picture><source media="(prefers-color-scheme: dark)" srcset="docs/assets/how-it-works-dark.svg"><img alt="PenEcho 工作原理" src="docs/assets/how-it-works-light.svg"></picture></p>
+
+浏览器只会发送与当前任务相关的画布区域及其几何信息。服务器验证请求并交给选定的执行器，然后返回可移动的结构化草稿。当前模型推荐和费用示例请参阅[英文 README](README.md#recommended-model-configurations)。
+
+## 安全部署
+
+- **Codex CLI 和 Claude CLI：** 仅应在本机或可信局域网内使用。有效请求会启动本地 CLI 进程，因此不要将这两种模式直接暴露在公网中。
+- **API 模式：** 如需提供公网访问，请将 PenEcho 部署在具备 HTTPS、身份验证、频率限制和请求大小限制的反向代理之后。
+- 不要公开配置文件、API Key、请求记录、日志或包含隐私内容的画布图片。
+
+## 参与开发
+
+提交改动前请运行：
+
+```bash
+npm run check
+```
+
+实现细节请参阅[架构说明](docs/architecture.md)，贡献流程请参阅 [CONTRIBUTING.md](CONTRIBUTING.md)。问题和使用案例可以发布到 [Discord](https://discord.gg/3jrPJ3mXdX) 或 [GitHub Discussions](https://github.com/penecho/penecho/discussions)，可复现的问题请提交到 [GitHub Issues](https://github.com/penecho/penecho/issues)。
+
+## 许可证与商业使用
+
+PenEcho 采用 [GNU AGPL v3.0 only](LICENSE) 开源许可证，允许商业使用。如果你修改 PenEcho 并通过网络向用户提供该版本，则必须按照 AGPL 的要求向这些用户提供对应的源代码。无法满足 AGPL 要求的专有产品或托管服务可以选择单独的[商业许可证](COMMERCIAL-LICENSE.md)。PenEcho 的名称和标志另受[商标政策](TRADEMARKS.md)约束。


### PR DESCRIPTION
## Summary

- Added localized README files for Simplified Chinese, Japanese, Korean, Russian, Spanish, Brazilian Portuguese, French, and German.
- Added a consistent language switcher to every README.
- Kept the English README as the canonical technical reference to reduce translation drift.
- Preserved detailed notes for the latest `0.7.0` release while condensing earlier release information into a concise changelog entry.
- No application code or version numbers were changed.

## Validation

- Ran `git diff --check`.
- Ran `npm run check`: all 200 tests passed.
- Validated local links across all nine README files.
- Verified that every README contains the complete language navigation.
- Previewed the English README in VS Code and confirmed that localized README links render correctly.

## Contributor agreement

- [x] I have read and agree to `CONTRIBUTOR-LICENSE-AGREEMENT.md` in this repository.
- [x] I have the right to submit this contribution, including any required permission from my employer or other rights holder.