### PR TITLE
Add MiniMax API presets and model metadata

### DIFF
--- a/desktop/settings/index.html
+++ b/desktop/settings/index.html
@@ -66,9 +66,11 @@
           </div>
           <div class="field-row two-column">
             <label><span data-i18n="apiType">API type</span><select name="apiFormat"><option value="openai">OpenAI-compatible</option><option value="anthropic">Anthropic-compatible</option></select></label>
-            <label><span data-i18n="model">Model</span><input name="apiModel" autocomplete="off" spellcheck="false" placeholder="gpt-5.6-sol"></label>
+            <label><span data-i18n="model">Model</span><input name="apiModel" list="apiModelPresets" autocomplete="off" spellcheck="false" placeholder="gpt-5.6-sol"></label>
           </div>
-          <label><span data-i18n="baseUrl">API base URL</span><input name="apiUrl" type="url" autocomplete="off" spellcheck="false" placeholder="https://api.openai.com/v1"></label>
+          <datalist id="apiModelPresets"><option value="MiniMax-M3" label="1,000,000-token context; text, image, and video input; adaptive or disabled thinking."></option><option value="MiniMax-M2.7" label="204,800-token context; text-only input; thinking always on."></option></datalist>
+          <label><span data-i18n="baseUrl">API base URL</span><input name="apiUrl" type="url" list="apiUrlPresets" autocomplete="off" spellcheck="false" placeholder="https://api.openai.com/v1"></label>
+          <datalist id="apiUrlPresets"><option value="https://api.minimax.io/v1" label="MiniMax Global - Chat Completions"></option><option value="https://api.minimax.io/anthropic" label="MiniMax Global - Messages"></option><option value="https://api.minimaxi.com/v1" label="MiniMax Mainland China - Chat Completions"></option><option value="https://api.minimaxi.com/anthropic" label="MiniMax Mainland China - Messages"></option></datalist>
           <label><span data-i18n="apiKey">API key</span><span class="input-with-badge"><input name="apiKey" type="password" autocomplete="off" placeholder="Paste your API key"><small id="savedKeyBadge" hidden data-i18n="savedLocally">Saved locally</small></span><small class="field-help" data-i18n="apiKeyHelp">Saved in a user-only local credential file and never exposed to the canvas page.</small></label>
         </section>
 

--- a/src/cli/configure-ui.js
+++ b/src/cli/configure-ui.js
@@ -2,6 +2,7 @@
 
 const fs = require("fs");
 const path = require("path");
+const { MINIMAX_ENDPOINTS, MINIMAX_MODELS } = require("../server/api-config.js");
 
 const PROVIDERS = {
   kimi: "kimi-cli",
@@ -9,6 +10,13 @@ const PROVIDERS = {
   codex: "codex-cli",
   api: "api",
 };
+
+const MINIMAX_API_PRESETS = Object.freeze([
+  Object.freeze({ value:"minimax-global-openai", name:"MiniMax - Global - Chat Completions", format:"openai", baseUrl:MINIMAX_ENDPOINTS.global_en.openaiBaseUrl }),
+  Object.freeze({ value:"minimax-global-anthropic", name:"MiniMax - Global - Messages", format:"anthropic", baseUrl:MINIMAX_ENDPOINTS.global_en.anthropicBaseUrl }),
+  Object.freeze({ value:"minimax-china-openai", name:"MiniMax - Mainland China - Chat Completions", format:"openai", baseUrl:MINIMAX_ENDPOINTS.cn_zh.openaiBaseUrl }),
+  Object.freeze({ value:"minimax-china-anthropic", name:"MiniMax - Mainland China - Messages", format:"anthropic", baseUrl:MINIMAX_ENDPOINTS.cn_zh.anthropicBaseUrl }),
+]);
 
 function cleanText(value) {
   return String(value ?? "").trim();
@@ -29,6 +37,29 @@ function uniqueChoices(choices) {
     seen.add(key);
     return true;
   });
+}
+
+function currentMinimaxApiPreset(format, url) {
+  const normalizedUrl = cleanText(url).replace(/\/+$/, "");
+  return MINIMAX_API_PRESETS.find(preset => (!format || preset.format === format) && preset.baseUrl === normalizedUrl) || null;
+}
+
+function minimaxModelDescription(model) {
+  const context = model.contextWindow.toLocaleString("en-US"), modalities = model.inputModalities,
+    input = modalities.length === 1 ? `${modalities[0]}-only input` : `${modalities.slice(0, -1).join(", ")}, and ${modalities.at(-1)} input`,
+    thinking = model.thinking.includes("always_on") ? "thinking always on" : "adaptive or disabled thinking";
+  return `${context}-token context; ${input}; ${thinking}.`;
+}
+
+async function chooseMinimaxModel(ui, current) {
+  const models = Object.values(MINIMAX_MODELS), choices = [
+    ...models.map(model => ({ name:model.modelId, value:model.modelId, description:minimaxModelDescription(model) })),
+    ...(current && !MINIMAX_MODELS[current] ? [{ name:`Current custom model: ${current}`, value:current }] : []),
+    { name:"Enter a model manually…", value:"__manual__", description:"Use another MiniMax model ID." },
+  ];
+  const selected = await ui.select("Model", uniqueChoices(choices), current || models[0].modelId);
+  if (selected !== "__manual__") return selected;
+  return cleanText(await ui.input("Model", current || models[0].modelId, textValidator("Model")));
 }
 
 function readJsonModel(file) {
@@ -147,9 +178,12 @@ async function chooseModel(ui, provider, configuration) {
   return cleanText(await ui.input("Model ID or alias", current || detected, textValidator("Model")));
 }
 
-async function chooseEffort(ui, provider, current, format = "") {
+async function chooseEffort(ui, provider, current, format = "", model = null) {
   const isKimi = provider === PROVIDERS.kimi, isCodex = provider === PROVIDERS.codex, isClaude = provider === PROVIDERS.claude,
-    defaultValue = current || (format === "anthropic" ? "medium" : isKimi ? "high" : isClaude ? "max" : "xhigh");
+    modelThinking = Array.isArray(model?.thinking) ? model.thinking : [], alwaysOn = modelThinking.includes("always_on"),
+    supportsDisabled = modelThinking.includes("disabled"), normalizedCurrent = cleanText(current),
+    currentValue = alwaysOn && normalizedCurrent.toLowerCase() === "none" ? "" : normalizedCurrent,
+    defaultValue = currentValue || (format === "anthropic" ? "medium" : isKimi ? "high" : isClaude ? "max" : "xhigh");
   const levels = isCodex
     ? [["low","Low"],["medium","Medium"],["high","High"],["xhigh","Extra high (maximum for Codex)"]]
     : isKimi
@@ -157,17 +191,17 @@ async function chooseEffort(ui, provider, current, format = "") {
       : isClaude
       ? [["none","None (thinking disabled)"],["low","Low"],["medium","Medium"],["high","High"],["max","Max"]]
       : format === "anthropic"
-        ? [["none","None (thinking disabled)"],["low","Low"],["medium","Medium (recommended)"],["high","High"],["max","Max"]]
-        : [["low","Low"],["medium","Medium"],["high","High"],["xhigh","Extra high (OpenAI-compatible maximum)"],["max","Max"]];
+        ? [...(alwaysOn ? [] : [["none","None (thinking disabled)"]]),["low","Low"],["medium","Medium (recommended)"],["high","High"],["max","Max"]]
+        : [...(supportsDisabled ? [["none","None (thinking disabled)"]] : []),["low","Low"],["medium","Medium"],["high","High"],["xhigh","Extra high (OpenAI-compatible maximum)"],["max","Max"]];
   const choices = [
     ...((isKimi || isCodex || isClaude) ? [{ name:`Use the ${isKimi ? "Kimi" : isCodex ? "Codex" : "Claude"} CLI default`, value:"", description:"Do not pass an explicit effort." }] : []),
     ...levels.map(([value, name]) => ({ name, value })),
-    ...(current && !levels.some(([value]) => value === current) ? [{ name:`Current custom value: ${current}`, value:current }] : []),
+    ...(currentValue && !levels.some(([value]) => value === currentValue) ? [{ name:`Current custom value: ${currentValue}`, value:currentValue }] : []),
     { name:"Enter a value manually…", value:"__manual__", description:"For model-specific or future effort levels." },
   ];
   const selected = await ui.select("Reasoning effort", uniqueChoices(choices), defaultValue);
   if (selected !== "__manual__") return selected;
-  return cleanText(await ui.input("Effort value", current, textValidator("Effort")));
+  return cleanText(await ui.input("Effort value", currentValue, textValidator("Effort")));
 }
 
 async function finishProviderConfiguration(ui, configuration, values, options) {
@@ -229,21 +263,27 @@ async function configureApi(ui, configuration, options) {
   ui.header("API", "Main menu  ›  LLM source  ›  API",
     "Choose the wire format used by your endpoint. Compatible gateways and local services are supported.");
   const env = configuration.env, currentFormat = apiValue(env, "FORMAT").toLowerCase(),
-    format = await ui.select("API type", [
+    currentUrl = apiValue(env, "URL"), currentModel = apiValue(env, "MODEL"),
+    currentPreset = currentMinimaxApiPreset(currentFormat, currentUrl),
+    selectedType = await ui.select("API type", [
       { name:"OpenAI-compatible", value:"openai", description:"Uses the Chat Completions request format." },
       { name:"Anthropic / Claude-compatible", value:"anthropic", description:"Uses the Claude Messages request format." },
-    ], ["openai","anthropic"].includes(currentFormat) ? currentFormat : "openai"),
-    sameFormat = format === currentFormat,
-    defaultUrl = sameFormat && apiValue(env, "URL") || (format === "anthropic" ? "https://api.anthropic.com" : "https://api.openai.com/v1"),
-    defaultModel = sameFormat && apiValue(env, "MODEL") || (format === "anthropic" ? "claude-opus-4-8" : "gpt-5.6-sol"),
+      ...MINIMAX_API_PRESETS.map(preset => ({ name:preset.name, value:preset.value, description:`Uses ${preset.baseUrl}.` })),
+    ], currentPreset?.value || (["openai","anthropic"].includes(currentFormat) ? currentFormat : "openai")),
+    preset = MINIMAX_API_PRESETS.find(candidate => candidate.value === selectedType) || null,
+    format = preset?.format || selectedType,
+    sameSelection = preset ? preset.value === currentPreset?.value : !currentPreset && format === currentFormat,
+    defaultUrl = sameSelection && currentUrl || preset?.baseUrl || (format === "anthropic" ? "https://api.anthropic.com" : "https://api.openai.com/v1"),
+    defaultModel = sameSelection && currentModel || (format === "anthropic" ? "claude-opus-4-8" : "gpt-5.6-sol"),
     apiUrl = cleanText(await ui.input("API base URL", defaultUrl, value => {
       try {
         const url = new URL(cleanText(value));
         return ["http:","https:"].includes(url.protocol) && url.hostname && !url.username && !url.password ? true : "Enter a valid HTTP(S) URL without embedded credentials.";
       } catch { return "Enter a valid HTTP(S) URL."; }
     })),
-    model = cleanText(await ui.input("Model", defaultModel, textValidator("Model"))),
-    effort = await chooseEffort(ui, PROVIDERS.api, sameFormat ? cleanText(env.AI_EFFORT) : "", format),
+    model = preset ? await chooseMinimaxModel(ui, sameSelection ? currentModel : "") : cleanText(await ui.input("Model", defaultModel, textValidator("Model"))),
+    modelMetadata = MINIMAX_MODELS[model] || null,
+    effort = await chooseEffort(ui, PROVIDERS.api, sameSelection ? cleanText(env.AI_EFFORT) : "", format, modelMetadata),
     currentKey = apiValue(env, "KEY"), enteredKey = cleanText(await ui.password(currentKey ? "API key (leave blank to keep the saved key)" : "API key")),
     key = enteredKey || currentKey;
   if (!key) {

--- a/src/server/api-config.js
+++ b/src/server/api-config.js
@@ -1,5 +1,35 @@
 "use strict";
 
+const MINIMAX_ENDPOINTS = Object.freeze({
+  global_en:Object.freeze({
+    openaiBaseUrl:"https://api.minimax.io/v1",
+    anthropicBaseUrl:"https://api.minimax.io/anthropic",
+    docsRoot:"https://platform.minimax.io/docs",
+  }),
+  cn_zh:Object.freeze({
+    openaiBaseUrl:"https://api.minimaxi.com/v1",
+    anthropicBaseUrl:"https://api.minimaxi.com/anthropic",
+    docsRoot:"https://platform.minimaxi.com/docs",
+  }),
+});
+
+const MINIMAX_MODELS = Object.freeze({
+  "MiniMax-M3":Object.freeze({
+    modelId:"MiniMax-M3",
+    contextWindow:1000000,
+    pricingUsdPerMillionTokens:Object.freeze({ input:0.6, output:2.4, cacheRead:0.12, cacheWrite:null }),
+    inputModalities:Object.freeze(["text", "image", "video"]),
+    thinking:Object.freeze(["adaptive", "disabled"]),
+  }),
+  "MiniMax-M2.7":Object.freeze({
+    modelId:"MiniMax-M2.7",
+    contextWindow:204800,
+    pricingUsdPerMillionTokens:Object.freeze({ input:0.3, output:1.2, cacheRead:0.06, cacheWrite:0.375 }),
+    inputModalities:Object.freeze(["text"]),
+    thinking:Object.freeze(["always_on"]),
+  }),
+});
+
 function resolveApiConfig(value, formatOverride) {
   if (!value) return null;
   const requestedFormat = String(formatOverride || "").trim().toLowerCase();
@@ -46,4 +76,11 @@ function anthropicResponseMaxTokens(effort) {
   return String(effort || "").trim().toLowerCase() === "max" ? 16384 : 12288;
 }
 
-module.exports = { anthropicEffortParameters, anthropicResponseMaxTokens, normalizedApiEffort, resolveApiConfig };
+module.exports = {
+  MINIMAX_ENDPOINTS,
+  MINIMAX_MODELS,
+  anthropicEffortParameters,
+  anthropicResponseMaxTokens,
+  normalizedApiEffort,
+  resolveApiConfig,
+};

--- a/test/api-config.test.js
+++ b/test/api-config.test.js
@@ -2,7 +2,38 @@
 
 const test = require("node:test");
 const assert = require("node:assert/strict");
-const { anthropicEffortParameters, anthropicResponseMaxTokens, normalizedApiEffort, resolveApiConfig } = require("../src/server/api-config.js");
+const {
+  MINIMAX_ENDPOINTS, MINIMAX_MODELS, anthropicEffortParameters, anthropicResponseMaxTokens, normalizedApiEffort, resolveApiConfig,
+} = require("../src/server/api-config.js");
+
+test("MiniMax presets retain current endpoint and model metadata", () => {
+  assert.deepEqual(MINIMAX_ENDPOINTS, {
+    global_en:{
+      openaiBaseUrl:"https://api.minimax.io/v1",
+      anthropicBaseUrl:"https://api.minimax.io/anthropic",
+      docsRoot:"https://platform.minimax.io/docs",
+    },
+    cn_zh:{
+      openaiBaseUrl:"https://api.minimaxi.com/v1",
+      anthropicBaseUrl:"https://api.minimaxi.com/anthropic",
+      docsRoot:"https://platform.minimaxi.com/docs",
+    },
+  });
+  assert.deepEqual(MINIMAX_MODELS["MiniMax-M3"], {
+    modelId:"MiniMax-M3",
+    contextWindow:1000000,
+    pricingUsdPerMillionTokens:{ input:0.6, output:2.4, cacheRead:0.12, cacheWrite:null },
+    inputModalities:["text", "image", "video"],
+    thinking:["adaptive", "disabled"],
+  });
+  assert.deepEqual(MINIMAX_MODELS["MiniMax-M2.7"], {
+    modelId:"MiniMax-M2.7",
+    contextWindow:204800,
+    pricingUsdPerMillionTokens:{ input:0.3, output:1.2, cacheRead:0.06, cacheWrite:0.375 },
+    inputModalities:["text"],
+    thinking:["always_on"],
+  });
+});
 
 test("API format selection builds the matching endpoint", () => {
   assert.deepEqual(resolveApiConfig("https://api.openai.com/v1", "openai"), {

--- a/test/configure-ui.test.js
+++ b/test/configure-ui.test.js
@@ -116,6 +116,56 @@ test("Anthropic API configuration offers none and defaults new selections to med
   assert.equal(effortPrompt.defaultValue, "medium");
 });
 
+test("MiniMax API presets expose regional endpoints and current model capabilities", async () => {
+  const directory = temporaryDirectory(), configuration = {
+    home:directory, stateDir:path.join(directory, ".penecho"), configFile:path.join(directory, "config.env"), env:{},
+  }, saved = [];
+  const ui = uiScript({
+    selections:["minimax-global-anthropic", "MiniMax-M3", "none", "save"],
+    passwords:["test-key"],
+  });
+  await runConfigureMenu(configuration, {
+    ui, directProvider:"api", save:async values => saved.push(values), test:async () => "ok",
+  });
+  const typePrompt = ui.selects.find(item => item.message === "API type"),
+    modelPrompt = ui.selects.find(item => item.message === "Model"),
+    effortPrompt = ui.selects.find(item => item.message === "Reasoning effort"),
+    m3 = modelPrompt.choices.find(choice => choice.value === "MiniMax-M3"),
+    m27 = modelPrompt.choices.find(choice => choice.value === "MiniMax-M2.7");
+  assert.ok(typePrompt.choices.some(choice => choice.value === "minimax-global-openai"));
+  assert.ok(typePrompt.choices.some(choice => choice.value === "minimax-global-anthropic"));
+  assert.ok(typePrompt.choices.some(choice => choice.value === "minimax-china-openai"));
+  assert.ok(typePrompt.choices.some(choice => choice.value === "minimax-china-anthropic"));
+  assert.match(m3.description, /1,000,000-token context/);
+  assert.match(m3.description, /text, image, and video input/);
+  assert.match(m3.description, /adaptive or disabled thinking/);
+  assert.match(m27.description, /204,800-token context/);
+  assert.match(m27.description, /text-only input/);
+  assert.match(m27.description, /thinking always on/);
+  assert.ok(effortPrompt.choices.some(choice => choice.value === "none"));
+  assert.equal(saved[0].AI_API_FORMAT, "anthropic");
+  assert.equal(saved[0].AI_API_URL, "https://api.minimax.io/anthropic");
+  assert.equal(saved[0].AI_API_MODEL, "MiniMax-M3");
+});
+
+test("MiniMax always-on thinking preset omits the disabled choice", async () => {
+  const directory = temporaryDirectory(), configuration = {
+    home:directory, stateDir:path.join(directory, ".penecho"), configFile:path.join(directory, "config.env"), env:{},
+  }, saved = [];
+  const ui = uiScript({
+    selections:["minimax-china-openai", "MiniMax-M2.7", "high", "save"],
+    passwords:["test-key"],
+  });
+  await runConfigureMenu(configuration, {
+    ui, directProvider:"api", save:async values => saved.push(values), test:async () => "ok",
+  });
+  const effortPrompt = ui.selects.find(item => item.message === "Reasoning effort");
+  assert.ok(effortPrompt.choices.every(choice => choice.value !== "none"));
+  assert.equal(saved[0].AI_API_FORMAT, "openai");
+  assert.equal(saved[0].AI_API_URL, "https://api.minimaxi.com/v1");
+  assert.equal(saved[0].AI_API_MODEL, "MiniMax-M2.7");
+});
+
 test("configured CLI models are discovered when local settings expose them", () => {
   const home = temporaryDirectory();
   fs.mkdirSync(path.join(home, ".codex"), { recursive:true });

--- a/test/desktop-package.test.js
+++ b/test/desktop-package.test.js
@@ -301,6 +301,14 @@ test("desktop shell and Forge config keep the renderer isolated and package nati
   assert.match(html, /data-install-cli="kimi-cli"/);
   assert.match(html, /github\.com\/MoonshotAI\/kimi-code/);
   assert.match(html, /data-i18n="installGuide">Guide<\/a>/);
+  assert.match(html, /name="apiModel" list="apiModelPresets"/);
+  assert.match(html, /value="MiniMax-M3" label="1,000,000-token context; text, image, and video input; adaptive or disabled thinking\."/);
+  assert.match(html, /value="MiniMax-M2\.7" label="204,800-token context; text-only input; thinking always on\."/);
+  assert.match(html, /name="apiUrl" type="url" list="apiUrlPresets"/);
+  for (const endpoint of [
+    "https://api.minimax.io/v1", "https://api.minimax.io/anthropic",
+    "https://api.minimaxi.com/v1", "https://api.minimaxi.com/anthropic",
+  ]) assert.match(html, new RegExp(`value="${endpoint.replaceAll(".", "\\.")}"`));
   assert.match(fs.readFileSync(path.join(ROOT, "desktop", "settings", "settings.css"), "utf8"), /\.inline-primary,\.inline-secondary\{[^}]*display:inline-flex[^}]*text-decoration:none/);
   assert.match(settings, /\["kimi-cli", "codex-cli", "claude-cli"\]\.includes\(selected\)/);
   assert.match(settings, /"kimi-cli":"kimiCliPath"/);


### PR DESCRIPTION
Reason: Add current MiniMax API presets and model capability metadata.

## Summary

- Add global and Mainland China presets for the MiniMax Chat Completions and Messages endpoints.
- Register MiniMax-M3 and MiniMax-M2.7 context, pricing, input modality, and thinking metadata.
- Offer the current MiniMax models and endpoints in the CLI and desktop API configuration interfaces.

## Validation

- `npm run check`

## Contributor agreement

- [x] I have read and agree to `CONTRIBUTOR-LICENSE-AGREEMENT.md` in this repository.
- [x] I have the right to submit this contribution, including any required permission from my employer or other rights holder.
