### PR TITLE
Polish canvas transitions and project dialogs

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -4815,7 +4815,7 @@ User writes “我需要根据地点, 显示空气质量”, names a place, and 
     if (!widget) return;
     const replacement = state.pendingWidgetReplacement;
     const pendingBefore = capturePendingHistoryState();
-    if (widget.revision !== state.userRevision) {
+    if (!options.allowRevisionMismatch && widget.revision !== state.userRevision) {
       rejectPendingWidget(AI_CANCELLED);
       setStatusKey("canvasChanged");
       return;
@@ -8506,9 +8506,25 @@ User writes “我需要根据地点, 显示空气质量”, names a place, and 
       if (!dialogSelect.value) dialogSelect.value = SERVER_DEFAULT_PROJECT_ID;
     }
   }
+  function openServerProjectDialog() {
+    const dialog = document.querySelector("#projectDialog"),
+      input = document.querySelector("#projectName");
+    input.value = "";
+    input.setCustomValidity("");
+    dialog.dataset.busy = "false";
+    if (!dialog.open) dialog.showModal();
+    queueMicrotask(() => input.focus());
+  }
   async function createServerProject() {
-    const name = prompt(t("canvasProjectName"), "")?.trim().slice(0, 48);
-    if (!name) return;
+    const dialog = document.querySelector("#projectDialog"),
+      input = document.querySelector("#projectName"),
+      name = input.value.trim().slice(0, 48);
+    if (!name) {
+      input.setCustomValidity(t("canvasProjectName"));
+      input.reportValidity();
+      return false;
+    }
+    input.setCustomValidity("");
     const response = await fetch("/api/canvas-projects", {
         method:"POST",
         credentials:"same-origin",
@@ -8518,7 +8534,9 @@ User writes “我需要根据地点, 显示空气质量”, names a place, and 
       body = await snapshotApiResponse(response);
     rememberSelectedServerProject(body.project.id);
     await refreshSnapshots();
+    if (dialog.open) dialog.close("created");
     showHistoryNoticeKey("canvasProjectCreated", "success");
+    return true;
   }
   async function deleteSelectedServerProject() {
     const project = serverCanvasProjects.find((item) => item.id === selectedServerProjectId);
@@ -12629,6 +12647,13 @@ User writes “我需要根据地点, 显示空气质量”, names a place, and 
     options ||= {};
     const button = document.querySelector(`[data-mode="${mode}"]`);
     if (!button) return;
+    const finalizingPendingWidgetForEraser = mode === "eraser" && ["hand", "pen"].includes(state.mode)
+      && !options.skipDraftFinalize && Boolean(state.pendingWidget);
+    if (finalizingPendingWidgetForEraser) {
+      state.aiDraftReturnMode = null;
+      state.pendingHistoryRestored = false;
+      acceptPendingWidget({ restoreMode:false, allowRevisionMismatch:true });
+    }
     const staysInWidgetRefineModes = ["pen", "hand"].includes(state.mode) && ["pen", "hand"].includes(mode);
     if (mode !== state.mode && !staysInWidgetRefineModes && !options.preserveWidgetRefinement && (activeWidgetRefinement() || state.pendingWidgetReplacement)) {
       state.aiDraftReturnMode = null;
@@ -13107,8 +13132,32 @@ User writes “我需要根据地点, 显示空气质量”, names a place, and 
     rememberSelectedServerProject(event.target.value);
     renderSnapshotList();
   };
-  document.querySelector("#historyProjectCreate").onclick = () => runSnapshotAction(createServerProject);
+  document.querySelector("#historyProjectCreate").onclick = openServerProjectDialog;
   document.querySelector("#historyProjectDelete").onclick = () => runSnapshotAction(deleteSelectedServerProject);
+  const projectDialog = document.querySelector("#projectDialog"),
+    projectForm = document.querySelector("#projectForm"),
+    closeProjectDialog = () => {
+      if (projectDialog.dataset.busy !== "true" && projectDialog.open) projectDialog.close("cancel");
+    };
+  document.querySelector("#projectDialogClose").onclick = closeProjectDialog;
+  document.querySelector("#projectDialogCancel").onclick = closeProjectDialog;
+  document.querySelector("#projectName").addEventListener("input", (event) => event.currentTarget.setCustomValidity(""));
+  projectDialog.addEventListener("cancel", (event) => {
+    if (projectDialog.dataset.busy === "true") event.preventDefault();
+  });
+  projectForm.addEventListener("submit", async (event) => {
+    event.preventDefault();
+    if (projectDialog.dataset.busy === "true") return;
+    projectDialog.dataset.busy = "true";
+    const buttons = [...projectForm.querySelectorAll("button")];
+    buttons.forEach((button) => (button.disabled = true));
+    try {
+      await runSnapshotAction(createServerProject);
+    } finally {
+      projectDialog.dataset.busy = "false";
+      buttons.forEach((button) => (button.disabled = false));
+    }
+  });
   document.querySelectorAll('input[name="historyStorageLocation"], input[name="newCanvasStorageLocation"]').forEach((input) => {
     input.addEventListener("change", () => {
       if (input.checked) setSnapshotLocation(input.value);

--- a/public/index.html
+++ b/public/index.html
@@ -215,6 +215,27 @@
       <div id="historyList" class="history-list" aria-live="polite"></div>
     </aside>
 
+    <dialog id="projectDialog" class="new-canvas-dialog project-dialog" aria-labelledby="projectDialogTitle">
+      <form id="projectForm">
+        <header>
+          <div><span class="history-kicker">PenEcho</span><h2 id="projectDialogTitle" data-i18n="canvasProjectNew">New project</h2></div>
+          <button id="projectDialogClose" class="new-canvas-close" type="button" data-i18n-aria="cancel" aria-label="Cancel" data-i18n-title="cancel" title="Cancel"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M6 6l12 12M18 6L6 18"/></svg></button>
+        </header>
+        <div class="new-canvas-fields project-dialog-fields">
+          <label class="new-snapshot-name" for="projectName"><span data-i18n="canvasProjectName">Project name</span>
+            <input id="projectName" type="text" maxlength="48" required data-i18n-placeholder="canvasProjectName" placeholder="Project name" autocomplete="off">
+          </label>
+        </div>
+        <div class="new-canvas-actions">
+          <div></div>
+          <div class="new-canvas-action-group">
+            <button id="projectDialogCancel" type="button" data-i18n="cancel">Cancel</button>
+            <button id="projectDialogCreate" class="new-canvas-primary" type="submit" data-i18n="canvasProjectNew">New project</button>
+          </div>
+        </div>
+      </form>
+    </dialog>
+
     <dialog id="newCanvasDialog" class="new-canvas-dialog" aria-labelledby="newCanvasTitle">
       <form method="dialog">
         <header>

--- a/public/style.css
+++ b/public/style.css
@@ -467,8 +467,8 @@ button:focus-visible, select:focus-visible, input:focus-visible, a:focus-visible
 .new-canvas-actions button { min-height: 36px; padding: 8px 13px; color: var(--ink); border: 1px solid var(--sheet-edge); border-radius: 9px; background: color-mix(in srgb, var(--panel-raised) 72%, transparent); font: 650 .72rem/1.1 system-ui, sans-serif; white-space: nowrap; cursor: pointer; transition: color .14s ease, border-color .14s ease, background .14s ease; }
 .new-canvas-actions button:hover:not(:disabled) { border-color: color-mix(in srgb, var(--gold-bright) 48%, var(--line)); background: var(--panel-raised); }
 .new-canvas-actions button:disabled { cursor: not-allowed; opacity: .42; }
-.new-canvas-actions #newCanvasCancel { color: var(--muted); border-color: transparent; background: transparent; }
-.new-canvas-actions #newCanvasCancel:hover:not(:disabled) { color: var(--ink); border-color: var(--sheet-hairline); background: color-mix(in srgb, var(--panel-raised) 66%, transparent); }
+.new-canvas-actions #newCanvasCancel, .new-canvas-actions #projectDialogCancel { color: var(--muted); border-color: transparent; background: transparent; }
+.new-canvas-actions #newCanvasCancel:hover:not(:disabled), .new-canvas-actions #projectDialogCancel:hover:not(:disabled) { color: var(--ink); border-color: var(--sheet-hairline); background: color-mix(in srgb, var(--panel-raised) 66%, transparent); }
 .new-canvas-actions .new-canvas-primary { color: var(--accent-ink); border-color: transparent; background: linear-gradient(180deg, var(--gold-bright), var(--gold)); font-weight: 700; box-shadow: 0 1px 2px rgba(0, 0, 0, .2), inset 0 1px rgba(255, 255, 255, .14); }
 .new-canvas-actions .new-canvas-primary:hover:not(:disabled) { border-color: transparent; background: linear-gradient(180deg, color-mix(in srgb, var(--gold-bright) 88%, #fff), var(--gold-bright)); }
 .new-canvas-actions .new-canvas-discard { padding-inline: 9px; color: var(--danger); border-color: transparent; background: transparent; }
@@ -485,6 +485,8 @@ button:focus-visible, select:focus-visible, input:focus-visible, a:focus-visible
   .new-canvas-project select, .new-snapshot-name input { min-height: 42px; }
 }
 .text-help-dialog { width: min(440px, calc(100vw - 24px)); max-height: calc(100dvh - 24px); overflow: auto; border-radius: 14px; }
+.project-dialog { width: min(420px, calc(100vw - 32px)); }
+.project-dialog-fields { margin-top: 14px; }
 .text-help-dialog ul { margin: 0; padding-left: 19px; color: var(--ink); font: .76rem/1.6 system-ui, sans-serif; }
 .text-help-dialog li + li { margin-top: 4px; }
 .text-help-example { margin-top: 14px; }

--- a/public/style.css
+++ b/public/style.css
@@ -346,7 +346,9 @@ button:focus-visible, select:focus-visible, input:focus-visible, a:focus-visible
 .history-composer > * + * { border-top: 1px solid var(--sheet-hairline); }
 .snapshot-location { min-width: 0; margin: 0; padding: 9px var(--sheet-gutter) 8px; border: 0; }
 .snapshot-location legend { margin-bottom: 6px; padding: 0; color: var(--muted); font: 700 .6rem/1.2 system-ui, sans-serif; letter-spacing: .12em; text-transform: uppercase; }
+.history-composer > .snapshot-location legend { float: left; width: 100%; }
 .snapshot-location-options { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 4px; padding: 3px; border: 1px solid var(--sheet-hairline); border-radius: 10px; background: var(--sheet-well); }
+.history-composer > .snapshot-location .snapshot-location-options { clear: both; }
 .snapshot-location-options label { position: relative; min-width: 0; cursor: pointer; }
 .snapshot-location-options input { position: absolute; opacity: 0; pointer-events: none; }
 .snapshot-location-options span { display: flex; min-height: 30px; align-items: center; justify-content: center; gap: 7px; padding: 5px 9px; color: var(--muted); border: 1px solid transparent; border-radius: 7px; font: 650 .72rem/1.2 system-ui, sans-serif; text-align: center; transition: color .15s ease, background .15s ease, border-color .15s ease, box-shadow .15s ease; }

--- a/src/client/app/canvas-runtime.js
+++ b/src/client/app/canvas-runtime.js
@@ -1681,7 +1681,7 @@
     if (!widget) return;
     const replacement = state.pendingWidgetReplacement;
     const pendingBefore = capturePendingHistoryState();
-    if (widget.revision !== state.userRevision) {
+    if (!options.allowRevisionMismatch && widget.revision !== state.userRevision) {
       rejectPendingWidget(AI_CANCELLED);
       setStatusKey("canvasChanged");
       return;

--- a/src/client/app/persistence.js
+++ b/src/client/app/persistence.js
@@ -927,9 +927,25 @@
       if (!dialogSelect.value) dialogSelect.value = SERVER_DEFAULT_PROJECT_ID;
     }
   }
+  function openServerProjectDialog() {
+    const dialog = document.querySelector("#projectDialog"),
+      input = document.querySelector("#projectName");
+    input.value = "";
+    input.setCustomValidity("");
+    dialog.dataset.busy = "false";
+    if (!dialog.open) dialog.showModal();
+    queueMicrotask(() => input.focus());
+  }
   async function createServerProject() {
-    const name = prompt(t("canvasProjectName"), "")?.trim().slice(0, 48);
-    if (!name) return;
+    const dialog = document.querySelector("#projectDialog"),
+      input = document.querySelector("#projectName"),
+      name = input.value.trim().slice(0, 48);
+    if (!name) {
+      input.setCustomValidity(t("canvasProjectName"));
+      input.reportValidity();
+      return false;
+    }
+    input.setCustomValidity("");
     const response = await fetch("/api/canvas-projects", {
         method:"POST",
         credentials:"same-origin",
@@ -939,7 +955,9 @@
       body = await snapshotApiResponse(response);
     rememberSelectedServerProject(body.project.id);
     await refreshSnapshots();
+    if (dialog.open) dialog.close("created");
     showHistoryNoticeKey("canvasProjectCreated", "success");
+    return true;
   }
   async function deleteSelectedServerProject() {
     const project = serverCanvasProjects.find((item) => item.id === selectedServerProjectId);

--- a/src/client/app/ui-bootstrap.js
+++ b/src/client/app/ui-bootstrap.js
@@ -398,6 +398,13 @@
     options ||= {};
     const button = document.querySelector(`[data-mode="${mode}"]`);
     if (!button) return;
+    const finalizingPendingWidgetForEraser = mode === "eraser" && ["hand", "pen"].includes(state.mode)
+      && !options.skipDraftFinalize && Boolean(state.pendingWidget);
+    if (finalizingPendingWidgetForEraser) {
+      state.aiDraftReturnMode = null;
+      state.pendingHistoryRestored = false;
+      acceptPendingWidget({ restoreMode:false, allowRevisionMismatch:true });
+    }
     const staysInWidgetRefineModes = ["pen", "hand"].includes(state.mode) && ["pen", "hand"].includes(mode);
     if (mode !== state.mode && !staysInWidgetRefineModes && !options.preserveWidgetRefinement && (activeWidgetRefinement() || state.pendingWidgetReplacement)) {
       state.aiDraftReturnMode = null;
@@ -876,8 +883,32 @@
     rememberSelectedServerProject(event.target.value);
     renderSnapshotList();
   };
-  document.querySelector("#historyProjectCreate").onclick = () => runSnapshotAction(createServerProject);
+  document.querySelector("#historyProjectCreate").onclick = openServerProjectDialog;
   document.querySelector("#historyProjectDelete").onclick = () => runSnapshotAction(deleteSelectedServerProject);
+  const projectDialog = document.querySelector("#projectDialog"),
+    projectForm = document.querySelector("#projectForm"),
+    closeProjectDialog = () => {
+      if (projectDialog.dataset.busy !== "true" && projectDialog.open) projectDialog.close("cancel");
+    };
+  document.querySelector("#projectDialogClose").onclick = closeProjectDialog;
+  document.querySelector("#projectDialogCancel").onclick = closeProjectDialog;
+  document.querySelector("#projectName").addEventListener("input", (event) => event.currentTarget.setCustomValidity(""));
+  projectDialog.addEventListener("cancel", (event) => {
+    if (projectDialog.dataset.busy === "true") event.preventDefault();
+  });
+  projectForm.addEventListener("submit", async (event) => {
+    event.preventDefault();
+    if (projectDialog.dataset.busy === "true") return;
+    projectDialog.dataset.busy = "true";
+    const buttons = [...projectForm.querySelectorAll("button")];
+    buttons.forEach((button) => (button.disabled = true));
+    try {
+      await runSnapshotAction(createServerProject);
+    } finally {
+      projectDialog.dataset.busy = "false";
+      buttons.forEach((button) => (button.disabled = false));
+    }
+  });
   document.querySelectorAll('input[name="historyStorageLocation"], input[name="newCanvasStorageLocation"]').forEach((input) => {
     input.addEventListener("change", () => {
       if (input.checked) setSnapshotLocation(input.value);

--- a/test/ui-controls.test.js
+++ b/test/ui-controls.test.js
@@ -229,6 +229,7 @@ test("hand is the only object interaction mode and uses dedicated, clamped move 
   assert.match(app, /acceptPendingWidget\(\{ showHint:true \}\)/);
   assert.match(mode, /view\.classList\.toggle\("hand-mode", mode === "hand"\)/);
   assert.match(mode, /requestInteractionLayerRender\(\)/);
+  assert.match(mode, /finalizingPendingWidgetForEraser = mode === "eraser"[\s\S]*?\["hand", "pen"\]\.includes\(state\.mode\)[\s\S]*?acceptPendingWidget\(\{ restoreMode:false, allowRevisionMismatch:true \}\)/);
   assert.match(mode, /leavingDraftHand[\s\S]*?acceptPending\(\{ restoreMode:false \}\)/);
   assert.match(functionSource(app, "beginCanvasPointerAction"), /state\.mode === "hand"[\s\S]*?state\.panGesture[\s\S]*?setCanvasCursor\("grabbing"\)/);
   assert.ok(pointerDown.indexOf('state.mode !== "hand"') < pointerDown.indexOf("widgetPointerHit(point"));
@@ -311,6 +312,46 @@ test("AI drafts temporarily enter Hand, restore the prior tool, and undo back to
   assert.match(restore, /setCanvasMode\("hand", \{ preserveSelection:true, skipDraftFinalize:true \}\)/);
   assert.match(applyHistory, /restorePendingHistoryState\(entry, side\)/);
   assert.match(app, /state\.pendingHistoryRestored && \(a === "undo" \|\| a === "redo"\)/);
+});
+
+test("switching from Pen to Eraser finalizes a pending widget regardless of revision drift", () => {
+  const setCanvasMode = functionSource(read("public/app.js"), "setCanvasMode"),
+    button = { classList:{ toggle() {} }, setAttribute() {} },
+    state = {
+      mode:"pen",
+      pending:null,
+      pendingWidget:{ id:"widget-1", revision:4 },
+      pendingWidgetReplacement:null,
+      aiDraftReturnMode:"pen",
+      pendingHistoryRestored:false,
+      selection:null,
+      pointerPreview:null,
+      busy:false,
+    };
+  let accepted = 0;
+  vm.runInNewContext(`(${setCanvasMode})("eraser")`, {
+    state,
+    document:{
+      querySelector:() => button,
+      querySelectorAll:() => [button],
+    },
+    activeWidgetRefinement:() => null,
+    acceptPendingWidget:(options) => {
+      assert.equal(options.restoreMode, false);
+      assert.equal(options.allowRevisionMismatch, true);
+      accepted++;
+      state.pendingWidget = null;
+    },
+    updateWidgetRefinePointer() {},
+    updateAutoControl() {},
+    deselectAnimation() {},
+    view:{ classList:{ toggle() {} } },
+    resetCanvasCursor() {},
+    requestInteractionLayerRender() {},
+  });
+  assert.equal(accepted, 1);
+  assert.equal(state.mode, "eraser");
+  assert.equal(state.pendingWidget, null);
 });
 
 test("contextual footer hints persist, settle from blue, and follow widget and tool behavior", () => {
@@ -994,6 +1035,7 @@ test("live widgets use native canvas chrome, state-aware iframe gestures, and th
   assert.match(functionSource(app, "widgetBounds"), /capturableWidgets\(region\)/);
   assert.match(functionSource(app, "drawWidgetsToContext"), /capturableWidgets\(region\)/);
   assert.match(functionSource(app, "renderExportCanvas"), /prepareVisibleWidgetSnapshots\(null, false\)[\s\S]*?scale = Math\.min\(1, EXPORT_MAX_DIMENSION \/ region\.w[\s\S]*?Math\.sqrt\(EXPORT_MAX_PIXELS \/ \(region\.w \* region\.h\)\)/);
+  assert.match(acceptPendingWidget, /!options\.allowRevisionMismatch && widget\.revision !== state\.userRevision[\s\S]*?rejectPendingWidget\(AI_CANCELLED\)/);
   assert.match(acceptPendingWidget, /if \(replacement\) \{[\s\S]*?unmountWidget\(widget\)[\s\S]*?\} else \{[\s\S]*?state\.widgets\.push\(widget\)[\s\S]*?widget\.shell\.classList\.remove\("pending"\)[\s\S]*?sendWidgetHostState\(widget/);
   assert.doesNotMatch(prepareSnapshots, /snapshotVersion === widget\.contentVersion/);
   assert.doesNotMatch(finishWidgetGesture, /requestWidgetSnapshot|scheduleWidgetSnapshot/);
@@ -1426,7 +1468,10 @@ test("canvas history clearly separates device-only and shared PenEcho server sto
   assert.match(functionSource(app, "serverSnapshotItems"), /fetch\("\/api\/canvas-projects"/);
   assert.match(functionSource(app, "saveServerSnapshot"), /method:overwriteId \? "PUT" : "POST"/);
   assert.match(functionSource(app, "deleteServerSnapshot"), /method:"DELETE"/);
-  for (const id of ["serverProjectManager", "historyProjectSelect", "historyProjectCreate", "historyProjectDelete", "newCanvasProjectField", "newCanvasProjectSelect"]) assert.match(html, new RegExp(`id="${id}"`));
+  for (const id of ["serverProjectManager", "historyProjectSelect", "historyProjectCreate", "historyProjectDelete", "projectDialog", "projectForm", "projectName", "projectDialogCancel", "projectDialogCreate", "newCanvasProjectField", "newCanvasProjectSelect"]) assert.match(html, new RegExp(`id="${id}"`));
+  assert.match(functionSource(app, "openServerProjectDialog"), /projectDialog[\s\S]*?showModal\(\)[\s\S]*?input\.focus\(\)/);
+  assert.match(functionSource(app, "createServerProject"), /projectName[\s\S]*?input\.value\.trim\(\)\.slice\(0, 48\)[\s\S]*?fetch\("\/api\/canvas-projects"[\s\S]*?dialog\.close\("created"\)/);
+  assert.doesNotMatch(app, /\bprompt\s*\(/);
   assert.match(functionSource(app, "storedServerProjectId"), /sessionStorage\.getItem\(SERVER_PROJECT_SESSION_KEY\)/);
   assert.match(functionSource(app, "rememberSelectedServerProject"), /sessionStorage\.setItem\(SERVER_PROJECT_SESSION_KEY, selectedServerProjectId\)/);
   assert.match(functionSource(app, "selectedServerSaveProjectId"), /selectedServerProjectId === SERVER_ALL_PROJECTS_ID \? SERVER_DEFAULT_PROJECT_ID/);


### PR DESCRIPTION
## Summary

- Preserve pending widgets when switching from Pen or Hand to Eraser, including when the canvas revision has changed.
- Replace the unsupported browser `prompt()` used for project creation with an in-app dialog that works in the macOS desktop build.
- Align the Save location spacing in Canvas History without affecting the New Canvas dialog.
- Keep the application version unchanged at 0.9.0.

## Validation

- `npm run check` — 371 tests passed.
- `node --test test/ui-controls.test.js` — 73 tests passed.
- Built the macOS arm64 DMG successfully.
- Verified the DMG with `hdiutil verify`.

## Contributor agreement

- [x] I have read and agree to `CONTRIBUTOR-LICENSE-AGREEMENT.md` in this repository.
- [x] I have the right to submit this contribution, including any required permission from my employer or other rights holder.