### PR TITLE
Release PenEcho 1.0.1

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -2,6 +2,17 @@ name: Desktop installers
 
 on:
   workflow_dispatch:
+    inputs:
+      target:
+        description: Build target
+        required: true
+        default: all
+        type: choice
+        options:
+          - all
+          - windows
+          - mac
+          - android
   push:
     tags:
       - "v*"
@@ -22,6 +33,7 @@ jobs:
       - run: npm run check
 
   mac:
+    if: github.event_name != 'workflow_dispatch' || inputs.target == 'all' || inputs.target == 'mac'
     needs: test
     environment: macos-signing
     env:
@@ -124,6 +136,7 @@ jobs:
           path: release/*
 
   windows:
+    if: github.event_name != 'workflow_dispatch' || inputs.target == 'all' || inputs.target == 'windows'
     needs: test
     environment: windows-signing
     runs-on: windows-2025
@@ -315,6 +328,7 @@ jobs:
           path: release/*
 
   android:
+    if: github.event_name != 'workflow_dispatch' || inputs.target == 'all' || inputs.target == 'android'
     needs: test
     runs-on: ubuntu-latest
     env:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "penecho",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "penecho",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@inquirer/prompts": "7.10.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "penecho",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Think with AI on a shared canvas for handwriting, equations, and diagrams",
   "productName": "PenEcho",
   "main": "desktop/main.js",

--- a/public/cloud-connect.js
+++ b/public/cloud-connect.js
@@ -987,7 +987,10 @@
         const list = el("div", { class:"cloud-canvas-list" });
         if (!projectCanvases.length) list.append(el("div", { class:"cloud-project-empty", text:cloudT("noCanvases") }));
         for (const canvas of projectCanvases.slice(0, 12)) {
-          const thumbnailUrl = canvas.previewDataUrl || (isCloudRuntime() ? `/api/v1/canvases/${encodeURIComponent(canvas.id)}/thumbnail` : "");
+          const revision = String(canvas.currentRevisionId || "").trim();
+          const thumbnailUrl = canvas.previewDataUrl || (isCloudRuntime() && revision
+            ? `/api/v1/canvases/${encodeURIComponent(canvas.id)}/thumbnail?revision=${encodeURIComponent(revision)}`
+            : "");
           const row = el("button", { class:"cloud-canvas-row", type:"button", onclick:() => openProjectCanvasHere(canvas.id, panel, row) }, [
             thumbnailUrl ? el("img", { src:thumbnailUrl, alt:"", loading:"lazy" }) : el("span", { class:"cloud-canvas-placeholder", text:"P" }),
             el("span", { class:"cloud-canvas-copy" }, [

--- a/src/server/cloud-connector.js
+++ b/src/server/cloud-connector.js
@@ -16,6 +16,30 @@ const CLOUD_REQUEST_TIMEOUT_MS = 30_000;
 const BROWSER_AUTHORIZATION_MS = 10 * 60_000;
 const PUBLIC_MESSAGE_TIMEOUT_MS = 3_500;
 const BROWSER_CALLBACK_PATH = "/api/cloud/sign-in/callback";
+const CLOUD_AI_CONTEXT_KEY = "__penechoCloudAi";
+const LOCAL_CONNECTION_ID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+function normalizedCloudAiConnectionId(value) {
+  const connectionId = typeof value === "string" ? value.trim() : "";
+  return LOCAL_CONNECTION_ID_PATTERN.test(connectionId) ? connectionId : null;
+}
+
+function cloudAiRelayRequest(payload) {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload) || !Object.hasOwn(payload, CLOUD_AI_CONTEXT_KEY)) {
+    return { payload, connectionId:null };
+  }
+  const context = payload[CLOUD_AI_CONTEXT_KEY], cleanPayload = { ...payload };
+  delete cleanPayload[CLOUD_AI_CONTEXT_KEY];
+  const connectionId = context && typeof context === "object" && !Array.isArray(context) && context.version === 1
+    ? normalizedCloudAiConnectionId(context.connectionId)
+    : null;
+  return { payload:cleanPayload, connectionId };
+}
+
+function cloudAiConnectionHeaders(context) {
+  const connectionId = normalizedCloudAiConnectionId(context?.connectionId);
+  return connectionId ? { "x-penecho-connection":connectionId } : {};
+}
 
 function normalizedOrigin(value) {
   const url = new URL(String(value || "").trim());
@@ -1091,9 +1115,16 @@ class CloudConnector {
 
   async handleRequest(socket, message) {
     try {
-      const executor = message.payload?.operation === "canvas.http" ? this.executeHttpRequest : this.executeRequest;
+      const operation = message.payload?.operation,
+        remoteCanvas = operation === "canvas.http",
+        canvasAi = operation === undefined,
+        executor = remoteCanvas ? this.executeHttpRequest : this.executeRequest,
+        timeoutMs = Number(message.timeoutMs) || 210_000;
       if (typeof executor !== "function") throw Object.assign(new Error("This PenEcho version does not support Remote Canvas."), { code:"remote_canvas_unsupported" });
-      const payload = await executor(message.payload, Number(message.timeoutMs) || 210_000);
+      const relayRequest = canvasAi ? cloudAiRelayRequest(message.payload) : null,
+        payload = relayRequest?.connectionId
+          ? await executor(relayRequest.payload, timeoutMs, { connectionId:relayRequest.connectionId })
+          : await executor(relayRequest ? relayRequest.payload : message.payload, timeoutMs);
       if (socket.readyState === WebSocket.OPEN) socket.send(JSON.stringify({ type: "response", requestId: message.requestId, ok: true, payload }));
     } catch (error) {
       if (socket.readyState === WebSocket.OPEN) socket.send(JSON.stringify({
@@ -1107,4 +1138,4 @@ class CloudConnector {
   }
 }
 
-module.exports = { CloudConnector, accountSessionExpired, normalizedOrigin, publicCanvasMessage, reconnectDelayMs };
+module.exports = { CloudConnector, accountSessionExpired, cloudAiConnectionHeaders, cloudAiRelayRequest, normalizedOrigin, publicCanvasMessage, reconnectDelayMs };

--- a/src/server/main.js
+++ b/src/server/main.js
@@ -28,7 +28,7 @@ const { DEFAULT_REASONING_EFFORT, apiReasoningParameters, normalizeReasoningEffo
 const { testConfiguredProvider } = require("../cli/main.js");
 const { NORMALIZE_TYPESET_POLICY } = require("./typeset.js");
 const { resolveWidgetEditPatchCommands, widgetSourceMirrorsHtml, widgetPatchContract, widgetPatchFiles } = require("./widget-patch.js");
-const { CloudConnector } = require("./cloud-connector.js");
+const { CloudConnector, cloudAiConnectionHeaders } = require("./cloud-connector.js");
 const { createRemoteCanvasHttpExecutor } = require("./remote-canvas-http.js");
 const PLUGIN_FORMAT = require("../../public/plugins.js");
 const DRAW = require("../../public/draw.js");
@@ -732,6 +732,16 @@ function normalizeCanvasTheme(theme) {
 }
 
 function send(res, code, data, type = "application/json; charset=utf-8", extraHeaders = {}) { res.writeHead(code, { "Content-Type": type, "Cache-Control": "no-store", ...extraHeaders }); res.end(typeof data === "string" ? data : JSON.stringify(data)); }
+function sendPrivateMutableImage(req, res, bytes, contentType = "image/webp") {
+  const etag = `"${crypto.createHash("sha256").update(bytes).digest("hex")}"`;
+  const headers = { "Cache-Control":"private, no-cache, must-revalidate", ETag:etag, "X-Content-Type-Options":"nosniff" };
+  if (req.headers["if-none-match"] === etag) {
+    res.writeHead(304, headers);
+    return res.end();
+  }
+  res.writeHead(200, { ...headers, "Content-Type":contentType, "Content-Length":bytes.length });
+  return res.end(bytes);
+}
 function sendCloudSignInResult(res, ok) {
   const nonce = crypto.randomBytes(18).toString("base64");
   const title = ok ? "PenEcho sign-in complete" : "PenEcho sign-in could not be completed";
@@ -2981,8 +2991,7 @@ const server = http.createServer(async (req, res) => {
       if(cloudCanvasThumbnailMatch&&CLOUD_RESOURCE_ID_PATTERN.test(cloudCanvasThumbnailMatch[1])&&req.method==="GET"){
         const result=await cloudConnector.cloudCanvasThumbnail(cloudCanvasThumbnailMatch[1]);
         if(!result)return send(res,404,{error:"Cloud Canvas preview was not found."});
-        res.writeHead(200,{"Content-Type":result.contentType,"Content-Length":result.bytes.length,"Cache-Control":"private, max-age=300","X-Content-Type-Options":"nosniff"});
-        return res.end(result.bytes);
+        return sendPrivateMutableImage(req,res,result.bytes,result.contentType);
       }
       if(cloudCanvasSaveMatch&&CLOUD_RESOURCE_ID_PATTERN.test(cloudCanvasSaveMatch[1])&&req.method==="POST"){
         const body=await readJson(req,35*1024*1024);
@@ -3002,8 +3011,7 @@ const server = http.createServer(async (req, res) => {
       const favoriteCloudThumbnail=url.pathname.match(/^\/api\/cloud\/favorites\/([0-9a-f-]{36})\/thumbnail$/i);
       if(favoriteCloudThumbnail&&req.method==="GET"){
         const result=await cloudConnector.widgetFavoriteThumbnail(favoriteCloudThumbnail[1]);
-        res.writeHead(200,{"Content-Type":result.contentType,"Content-Length":result.bytes.length,"Cache-Control":"private, max-age=300","X-Content-Type-Options":"nosniff"});
-        return res.end(result.bytes);
+        return sendPrivateMutableImage(req,res,result.bytes,result.contentType);
       }
       if(req.method==="GET"&&url.pathname==="/api/cloud/favorites/feed"){
         const favoriteCloudError=cloudBrowserRequestError(req);
@@ -3105,8 +3113,7 @@ const server = http.createServer(async (req, res) => {
     const favorite=(await readLocalFavorites()).find((entry)=>entry.artifactSha256===localFavoriteThumbnailMatch[1]);
     const bytes=favorite?.thumbnail?Buffer.from(String(favorite.thumbnail),"base64"):Buffer.alloc(0);
     if(!bytes.length)return send(res,404,{error:"Favorite thumbnail not found."});
-    res.writeHead(200,{"Content-Type":"image/webp","Content-Length":bytes.length,"Cache-Control":"private, max-age=300","X-Content-Type-Options":"nosniff"});
-    return res.end(bytes);
+    return sendPrivateMutableImage(req,res,bytes);
   }
   const localFavoriteCloudMatch = url.pathname.match(/^\/api\/favorites\/([0-9a-f]{64})\/cloud$/);
   if (localFavoriteCloudMatch && req.method === "PATCH") {
@@ -3620,14 +3627,14 @@ ${WIDGET_PATCH_FORMAT_POLICY}`,
   if (req.method === "HEAD") return res.end();
   fs.createReadStream(file).pipe(res);
 });
-async function executeCloudCommand(payload, timeoutMs) {
+async function executeCloudCommand(payload, timeoutMs, context = null) {
   const address=server.address();
   if(!address||typeof address!=="object")throw new Error("Local PenEcho server is not listening.");
   const port=address.port,origin=`http://127.0.0.1:${port}`,host=`127.0.0.1:${port}`,
     cookieName=`${AI_SESSION_COOKIE_PREFIX}_${crypto.createHash("sha256").update(host).digest("hex").slice(0,12)}`,
     controller=new AbortController(),timeout=setTimeout(()=>controller.abort(),Math.max(10000,Math.min(Number(timeoutMs)||AI_REQUEST_TIMEOUT_MS,AI_REQUEST_TIMEOUT_MS)));
   try {
-    const response=await fetch(`${origin}/api/ai/command`,{method:"POST",signal:controller.signal,headers:{"content-type":"application/json",accept:"application/json",origin,cookie:`${cookieName}=${AI_SESSION_TOKEN}`},body:JSON.stringify(payload)});
+    const response=await fetch(`${origin}/api/ai/command`,{method:"POST",signal:controller.signal,headers:{"content-type":"application/json",accept:"application/json",origin,cookie:`${cookieName}=${AI_SESSION_TOKEN}`,...cloudAiConnectionHeaders(context)},body:JSON.stringify(payload)});
     const body=await response.json().catch(()=>({}));
     if(!response.ok){const error=new Error(body.error||`Local AI request failed (HTTP ${response.status}).`);error.code=body.errorCode||"local_ai_error";error.status=response.status;throw error}
     return body;

--- a/test/cloud-connect-ui.test.js
+++ b/test/cloud-connect-ui.test.js
@@ -1034,6 +1034,24 @@ test("Cloud Center opens project Canvases in the current local Canvas", async ()
   assert.deepEqual(run.opened, [], "opening a Canvas must not navigate to PenEcho Cloud");
 });
 
+test("Cloud-hosted Canvas thumbnails use the immutable revision as their cache key", async () => {
+  const projectId = "123e4567-e89b-42d3-a456-426614174011", canvasId = "123e4567-e89b-42d3-a456-426614174012", revisionId = "123e4567-e89b-42d3-a456-426614174013";
+  const library = { workspace:{}, projects:[{ id:projectId, name:"Research" }], canvases:[{ id:canvasId, projectId, currentRevisionId:revisionId, name:"Notes", updatedAt:Date.now(), sizeBytes:42 }], sync:{ bundleVersion:2, conflictPolicy:"base-revision-required" } };
+  const run = boot({ runtime:"cloud", status:deviceStatus(), remoteCloudStatus:{ accountName:"Remote User", deviceOnline:true }, library });
+  await run.flush();
+  const overlay = await openCloudCenter(run);
+  await run.flush();
+  const thumbnail = run.document.createdElements.find((node) => node.tagName === "IMG" && String(node.getAttribute("src") || "").includes(canvasId));
+  assert.equal(thumbnail?.getAttribute("src"), `/api/v1/canvases/${canvasId}/thumbnail?revision=${revisionId}`);
+});
+
+test("local mutable image proxies revalidate instead of caching stale Canvas and Favorite previews", () => {
+  assert.match(serverSource, /function sendPrivateMutableImage\(req, res, bytes/);
+  assert.match(serverSource, /private, no-cache, must-revalidate/);
+  assert.match(serverSource, /sendPrivateMutableImage\(req,res,result\.bytes,result\.contentType\)/);
+  assert.match(serverSource, /sendPrivateMutableImage\(req,res,bytes\)/);
+});
+
 test("Cloud Center opens favorite Canvases in the current local Canvas", async () => {
   const canvas = { id:"123e4567-e89b-42d3-a456-426614174004", kind:"canvas", name:"Plan", author:{ name:"Ada" } };
   const canvasArtifact = { version:2, bundleVersion:2, mode:"snapshot", manifest:{ format:"penecho-raster-tiles" } };

--- a/test/cloud-connector.test.js
+++ b/test/cloud-connector.test.js
@@ -7,7 +7,7 @@ const path = require("node:path");
 const { createHash } = require("node:crypto");
 const { test } = require("node:test");
 const { WebSocket, WebSocketServer } = require("ws");
-const { CloudConnector, accountSessionExpired, normalizedOrigin, publicCanvasMessage, reconnectDelayMs } = require("../src/server/cloud-connector.js");
+const { CloudConnector, accountSessionExpired, cloudAiConnectionHeaders, cloudAiRelayRequest, normalizedOrigin, publicCanvasMessage, reconnectDelayMs } = require("../src/server/cloud-connector.js");
 
 async function eventually(predicate, message, timeoutMs = 2000) {
   const deadline = Date.now() + timeoutMs;
@@ -1210,6 +1210,65 @@ test("cloud relay requests execute through the local model callback without expo
   } finally {
     fs.rmSync(stateDir, { recursive: true, force: true });
   }
+});
+
+test("cloud Canvas model selection reaches the local callback without leaking relay metadata", async () => {
+  const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "penecho-cloud-model-selection-test-"));
+  try {
+    const connectionId = "123e4567-e89b-42d3-a456-426614174080";
+    let receivedArguments = null;
+    const connector = new CloudConnector({
+      stateDir,
+      executeRequest: async (...args) => {
+        receivedArguments = args;
+        return { result:{ intent:"answer", commands:[] }, provider:"api" };
+      },
+    });
+    let sent = null;
+    const socket = { readyState:WebSocket.OPEN, send:value => { sent = JSON.parse(value); } };
+    await connector.handleRequest(socket, {
+      type:"request",
+      requestId:"selected-model",
+      timeoutMs:12_345,
+      payload:{ userAction:"answer", __penechoCloudAi:{ version:1, connectionId } },
+    });
+    assert.deepEqual(receivedArguments, [{ userAction:"answer" }, 12_345, { connectionId }]);
+    assert.equal(JSON.stringify(receivedArguments).includes("__penechoCloudAi"), false);
+    assert.equal(sent.ok, true);
+  } finally {
+    fs.rmSync(stateDir, { recursive:true, force:true });
+  }
+});
+
+test("invalid Cloud model context is removed and falls back to the default local connection", async () => {
+  const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "penecho-cloud-model-fallback-test-"));
+  try {
+    let receivedArguments = null;
+    const connector = new CloudConnector({ stateDir, executeRequest:async (...args) => { receivedArguments = args; return {}; } });
+    const socket = { readyState:WebSocket.OPEN, send:() => {} };
+    await connector.handleRequest(socket, {
+      type:"request",
+      requestId:"invalid-model",
+      timeoutMs:12_345,
+      payload:{ userAction:"answer", __penechoCloudAi:{ version:2, connectionId:"not-a-uuid" } },
+    });
+    assert.deepEqual(receivedArguments, [{ userAction:"answer" }, 12_345]);
+    assert.deepEqual(cloudAiConnectionHeaders(), {});
+    assert.deepEqual(cloudAiConnectionHeaders({ connectionId:"not-a-uuid" }), {});
+    assert.deepEqual(cloudAiConnectionHeaders({ connectionId:"123e4567-e89b-42d3-a456-426614174080" }), {
+      "x-penecho-connection":"123e4567-e89b-42d3-a456-426614174080",
+    });
+    assert.deepEqual(cloudAiRelayRequest({ userAction:"answer" }), { payload:{ userAction:"answer" }, connectionId:null });
+  } finally {
+    fs.rmSync(stateDir, { recursive:true, force:true });
+  }
+});
+
+test("Cloud model context is applied only at the local AI loopback boundary", () => {
+  const source = fs.readFileSync(path.join(__dirname, "..", "src", "server", "main.js"), "utf8");
+  assert.match(source, /async function executeCloudCommand\(payload, timeoutMs, context = null\)/);
+  assert.match(source, /headers:\{[^\n]+\.\.\.cloudAiConnectionHeaders\(context\)[^\n]+body:JSON\.stringify\(payload\)/);
+  assert.match(source, /findConnection\(store, requestedId\) \|\| store\.defaultConnection/);
 });
 
 test("Remote Canvas relay operations use the isolated HTTP callback", async () => {

--- a/test/desktop-package.test.js
+++ b/test/desktop-package.test.js
@@ -333,7 +333,7 @@ test("desktop shell and Forge config keep the renderer isolated and package nati
   assert.match(otherGroup, /value="codex-cli"/);
   assert.match(otherGroup, /value="claude-cli"/);
   assert.ok(html.indexOf("kimi-provider-group") < html.indexOf("otherProviderGroupTitle"));
-  assert.equal(rootPackage.version, "1.0.0");
+  assert.equal(rootPackage.version, "1.0.1");
   assert.match(html, /data-install-cli="kimi-cli"/);
   assert.match(html, /github\.com\/MoonshotAI\/kimi-code/);
   assert.match(html, /data-i18n="installGuide">Guide<\/a>/);

--- a/test/update.test.js
+++ b/test/update.test.js
@@ -43,7 +43,7 @@ test("npm latest-version lookup uses the registry latest endpoint and validates 
   assert.equal(latest, "0.6.0");
   assert.equal(calls[0].url, "https://registry.npmjs.org/penecho/latest");
   assert.equal(calls[0].options.redirect, "error");
-  assert.equal(calls[0].options.headers["User-Agent"], "penecho/1.0.0");
+  assert.equal(calls[0].options.headers["User-Agent"], "penecho/1.0.1");
   await assert.rejects(
     fetchLatestNpmVersion("penecho", { timeoutMs:1000, attempts:1, fetchImpl:async () => ({ ok:true, status:200, json:async () => ({ version:"invalid" }) }) }),
     /invalid PenEcho version/,


### PR DESCRIPTION
## Summary

- Release PenEcho 1.0.1.
- Honor Cloud Canvas model selection and refresh thumbnails correctly.

## Validation

- Client build check passed.
- Relevant Cloud, relay, and desktop tests passed: 128/128.

## Contributor agreement

- [x] I have read and agree to `CONTRIBUTOR-LICENSE-AGREEMENT.md` in this repository.
- [x] I have the right to submit this contribution, including any required permission from my employer or other rights holder.